### PR TITLE
Mermaid parser got confused by comma and slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,18 @@ Run any `/sdd:*` command and the plugin will automatically initialize:
 ```mermaid
 flowchart TD
     Start([User Request]) --> HasIdea{Have rough<br/>idea?}
-    HasIdea -->|Yes| Brainstorm[/sdd:brainstorm<br/>Refine idea to Spec]
-    HasIdea -->|"No, clear reqs"| Spec[/sdd:spec<br/>Create spec directly]
+    HasIdea -->|Yes| Brainstorm["/sdd:brainstorm<br/>Refine idea to Spec"]
+    HasIdea -->|"No, clear reqs"| Spec["/sdd:spec<br/>Create spec directly"]
 
-    Brainstorm --> Review[/sdd:review-spec<br/>Validate spec]
+    Brainstorm --> Review["/sdd:review-spec<br/>Validate spec"]
     Spec --> Review
 
-    Review --> Implement[/sdd:implement<br/>TDD + Compliance]
+    Review --> Implement["/sdd:implement<br/>TDD + Compliance"]
 
-    Implement --> Verify[Verification<br/>Tests + Spec Check]
+    Implement --> Verify["Verification<br/>Tests + Spec Check"]
 
     Verify -->|Pass| Done([Complete])
-    Verify -->|Drift| Evolve[/sdd:evolve<br/>Reconcile]
+    Verify -->|Drift| Evolve["/sdd:evolve<br/>Reconcile"]
 
     Evolve -->|Update Spec| Review
     Evolve -->|Fix Code| Implement


### PR DESCRIPTION
# Changes

- :bug: Fix Mermaid diagram rendering on GitHub README

/kind bug

Fixes rendering error in the workflow cheat sheet diagram. GitHub's
Mermaid parser was choking on:
1. Commas in edge labels (wrapped in quotes now)
2. Forward slashes in node labels like `/sdd:brainstorm` (also quoted)

The diagram renders correctly on GitHub now.
  
**Release Note**

N/A Just a documentation fix. The original author should not blindly trust his AI agent next time :-)
