### PR TITLE
fix: bump marketplace.json version to 2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "sdd",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Specification-Driven Development with Process Discipline for Claude Code",
       "author": {
         "name": "Roland Huss",


### PR DESCRIPTION
## Summary

- The `version` field in `.claude-plugin/marketplace.json` was still `1.0.0` despite the `v2.0.0` git tag
- The plugin update checker compares the `version` field in `marketplace.json`, not git tags, so users are told they're already on the latest version when they're not

## Test plan

- [ ] Install plugin from marketplace and verify `/plugin` correctly detects 2.0.0
- [ ] Verify users on 1.0.0 are prompted to update

🤖 Generated with [Claude Code](https://claude.com/claude-code)