### PR TITLE
Workflow-Based Setup [Spec]

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,1 @@
-{
-  "feature_directory": "specs/036-extension-local-scripts"
-}
+{"feature_directory": "specs/037-workflow-setup"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-22
 
 ## Active Technologies
 
-- Bash (POSIX-compatible), Markdown, Python 3 (hooks), `jq`, `specify` CLI (spec-kit)
+- Bash (POSIX-compatible), Markdown, Python 3 (hooks), `jq`, `yq`, `specify` CLI (spec-kit)
 
 ## Project Structure
 
@@ -16,6 +16,8 @@ spex/
     spex-worktrees/    # Git worktree isolation
     spex-teams/        # Parallel agent orchestration
     spex-deep-review/  # Multi-agent code review
+    spex-collab/       # Collaborative PR workflows
+    spex-detach/       # Strip spec artifacts for upstream PRs
   skills/              # Standalone skills (init/)
   scripts/             # Shell/Python scripts and hooks
   docs/                # Tutorials and help
@@ -34,6 +36,7 @@ Bash (POSIX-compatible, uses `jq` for JSON), Markdown for commands/skills: Follo
 - `spex-teams`: Parallel implementation via Claude Code Agent Teams (experimental)
 - `spex-deep-review`: Multi-agent code review with 5 specialized review agents and autonomous fix loop
 - `spex-collab`: Collaborative PR workflows (REVIEWERS.md, phase-split, phase-manager, revise, reconcile)
+- `spex-detach`: Strip spec artifacts at PR time for contributing to repos that don't use SDD
 
 ## GitHub Issues
 
@@ -56,5 +59,5 @@ Do not treat documentation as a follow-up task. Stale docs mislead users and ero
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/036-extension-local-scripts/plan.md
+at specs/037-workflow-setup/plan.md
 <!-- SPECKIT END -->

--- a/Makefile
+++ b/Makefile
@@ -69,20 +69,22 @@ release: validate sync-scripts-check test-install
 	fi; \
 	echo "Releasing v$$VERSION..."; \
 	echo ""; \
-	echo "Updating version to $$VERSION in marketplace.json, plugin.json, and spex/VERSION..."; \
+	echo "Updating version to $$VERSION in marketplace.json, plugin.json, setup.yml, bundle.yml, and spex/VERSION..."; \
 	tmp=$$(mktemp); \
 	jq --arg v "$$VERSION" '(.plugins[] | select(.name == "spex")).version = $$v' .claude-plugin/marketplace.json > "$$tmp" && mv "$$tmp" .claude-plugin/marketplace.json; \
 	tmp=$$(mktemp); \
 	jq --arg v "$$VERSION" '.version = $$v' spex/.claude-plugin/plugin.json > "$$tmp" && mv "$$tmp" spex/.claude-plugin/plugin.json; \
+	sed -i.bak "s/^  version: \".*\"/  version: \"$$VERSION\"/" spex/setup.yml && rm -f spex/setup.yml.bak; \
+	sed -i.bak "s/^  version: \".*\"/  version: \"$$VERSION\"/" spex/bundle.yml && rm -f spex/bundle.yml.bak; \
 	echo "$$VERSION" > spex/VERSION; \
-	git add VERSION spex/VERSION .claude-plugin/marketplace.json spex/.claude-plugin/plugin.json; \
+	git add VERSION spex/VERSION .claude-plugin/marketplace.json spex/.claude-plugin/plugin.json spex/setup.yml spex/bundle.yml; \
 	git commit -m "chore: bump version to $$VERSION"; \
 	echo "Creating tag v$$VERSION..."; \
 	git tag "v$$VERSION"; \
 	echo "Pushing release commit and tag..."; \
 	git push && git push origin "v$$VERSION"; \
 	echo "Creating GitHub release..."; \
-	gh release create "v$$VERSION" --generate-notes; \
+	gh release create "v$$VERSION" spex/setup.yml --generate-notes; \
 	echo ""; \
 	PATCH=$$(echo "$$VERSION" | cut -d. -f3); \
 	NEXT_PATCH=$$((PATCH + 1)); \

--- a/README.md
+++ b/README.md
@@ -192,7 +192,23 @@ make install
 /spex:init
 ```
 
-This runs Spec-Kit's `specify init`, installs all six bundled extensions, and asks about permissions. After initialization, extension hooks fire automatically at spec-kit lifecycle boundaries.
+This runs Spec-Kit's `specify init`, installs seven bundled extensions (six enabled by default, spex-detach opt-in), and configures permissions. After initialization, extension hooks fire automatically at spec-kit lifecycle boundaries.
+
+### Coming in 6.x: Workflow-Based Setup
+
+Starting with spex 6.0, a spec-kit setup workflow replaces the plugin-based init as the primary install path. The workflow is harness-agnostic (Claude Code, Codex, OpenCode) and executable from a single command:
+
+```bash
+# Install from GitHub release URL (no clone needed)
+specify workflow run https://github.com/rhuss/cc-spex/releases/latest/download/setup.yml
+
+# Customize with inputs
+specify workflow run spex/setup.yml -i "extensions=spex-gates,spex-worktrees"
+specify workflow run spex/setup.yml -i "permissions=yolo"
+specify workflow run spex/setup.yml -i "integration=codex"
+```
+
+The workflow auto-detects the agent harness, installs extensions, and applies per-agent configuration. Prerequisites: `specify` CLI (>= 0.7.4), `git`, and `jq`. The existing Claude Code plugin will delegate to this workflow when available, falling back to direct init otherwise.
 
 ## The Extensions System
 
@@ -257,7 +273,7 @@ These commands are provided by spex extensions and available after `/spex:init`.
 
 | Command | Extension | Purpose |
 |---------|-----------|---------|
-| `/spex:init` | (plugin) | Initialize Spec-Kit, install extensions, configure permissions |
+| `/spex:init` | (plugin) | Initialize Spec-Kit, install extensions, configure permissions (6.x: delegates to setup workflow) |
 | `/speckit-spex-brainstorm` | spex | Refine a rough idea into a structured brainstorm document as input for `/speckit-specify` |
 | `/speckit-spex-ship` | spex | Run the full workflow autonomously |
 | `/speckit-spex-evolve` | spex | Reconcile spec/code drift with guided resolution |

--- a/brainstorm/00-overview.md
+++ b/brainstorm/00-overview.md
@@ -1,6 +1,6 @@
 # Brainstorm Overview
 
-Last updated: 2026-07-06
+Last updated: 2026-07-07
 
 ## Sessions
 
@@ -38,7 +38,8 @@ Last updated: 2026-07-06
 | 30 | 2026-07-03 | closeout-gate | active | - | [#9](https://github.com/rhuss/cc-spex/issues/9) |
 | 31 | 2026-07-04 | plugin-discovery-fix | parked | - | [#7](https://github.com/rhuss/cc-spex/issues/7) |
 | 32 | 2026-07-04 | update-check | active | - | [#12](https://github.com/rhuss/cc-spex/issues/12) |
-| 33 | 2026-07-06 | extension-local-scripts | active | - | - |
+| 33 | 2026-07-06 | extension-local-scripts | spec-created | 036 | [#13](https://github.com/rhuss/cc-spex/pull/13) |
+| 34 | 2026-07-07 | workflow-based-setup | active | - | - |
 
 ## Open Threads
 - Superpowers availability detection mechanism (from #10)
@@ -106,6 +107,11 @@ Last updated: 2026-07-06
 - Should the repo URL for the API call be hardcoded or derived from git remote? (from #32)
 - Should spex-init.sh (hooks, adapters) also be refactored into the extension model? (from #33)
 - Build-time sync: Makefile target only, or also git pre-commit hook? (from #33)
+- Can workflow `prompt` step output be used in subsequent `if`/`switch` conditions? (from #34)
+- Does `specify bundle install` handle extension dependency ordering? (from #34)
+- Minimum spec-kit version required for workflow + bundle support? (from #34)
+- Should the setup workflow be idempotent (safe to re-run)? (from #34)
+- Neutral vocabulary for subagent dispatch (ship/teams/deep-review CC coupling) (from #34)
 
 ## Parked Ideas
 - Plugin discovery fix (#31): Plugin marketplace install resolves plugin source incorrectly for nested plugin structures.

--- a/brainstorm/27-worktree-cwd-persistence.md
+++ b/brainstorm/27-worktree-cwd-persistence.md
@@ -50,3 +50,92 @@ User types `/cd /path/to/worktree` after the pipeline creates it. Relocates the 
 - Should existing sibling worktrees be automatically detected and offered for migration?
 - Should the `EnterWorktree` tool be used instead of raw `git worktree add` when inside Claude Code? (It handles CWD switching at the harness level)
 - Does the worktree finish/cleanup flow need changes when worktrees are inside `.claude/`?
+
+---
+
+## Revisit: 2026-07-08
+
+### Updated Problem Framing
+
+The original fix (moving to `.claude/worktrees/`) solved CWD persistence for Claude Code but introduced a harness coupling. Each agent harness has different worktree conventions:
+
+- **Claude Code**: Native `EnterWorktree` tool uses `.claude/worktrees/`. Spex worktrees use `git worktree add` directly but default to the same path.
+- **Codex**: No native worktree tool. Raw `git worktree add` only. No `.codex/worktrees/` convention exists.
+- **OpenCode**: Same as Codex, raw git commands only.
+
+Two problems surfaced during feature 037-workflow-setup:
+
+1. **Harness-coupled default path**: `.claude/worktrees/` ties the worktree extension to Claude Code's directory layout. Codex and OpenCode users get a `.claude/` directory they didn't ask for.
+
+2. **Statusline can't see worktree state from main repo**: When a session opens the main repo while a ship pipeline runs in a worktree, the statusline shows nothing. The script checks `workspace.current_dir` (from Claude Code's stdin JSON), CWD, and `CLAUDE_PROJECT_DIR`, none of which point to the worktree.
+
+### Analysis: Statusline Visibility
+
+The statusline currently has 5 resolution priorities:
+1. `SHIP_STATE_FILE` env var
+2. `workspace.current_dir` from stdin JSON
+3. CWD `.specify/.spex-state`
+4. `workspace.project_dir` from stdin JSON
+5. `CLAUDE_PROJECT_DIR` env var
+
+With parallel worktree sessions, a main-repo session cannot meaningfully show a single worktree's status (which one?). The correct behavior: each session shows its own state, based on its CWD. Main repo sessions correctly show nothing (no pipeline running there).
+
+This means the fix is "ensure sessions always have the correct CWD", not "scan worktrees from the main repo."
+
+### New Approaches Considered
+
+#### D: Neutral default path `.worktrees/`
+
+Change the default `base_path` from `.claude/worktrees` to `.worktrees/`. No harness prefix. Add `.worktrees/` to `.gitignore` during setup.
+
+- Pros: Harness-neutral, no `.claude/` directory on non-Claude harnesses, short path
+- Cons: New top-level dotdir. Not inside any harness's project boundary by default (CWD persistence depends on harness behavior).
+
+#### E: Per-harness CWD switch strategy
+
+Each harness needs a different mechanism to switch CWD and keep it stable:
+
+| Harness | CWD Switch Mechanism | Persistence |
+|---------|---------------------|-------------|
+| Claude Code | `EnterWorktree` or `cd` (if inside project boundary) | Stable if worktree is inside project boundary |
+| Codex | `cd` in hook or instruction | Unknown, needs testing |
+| OpenCode | `cd` in plugin | Unknown, needs testing |
+
+The worktree manage command would detect the harness and use the appropriate mechanism.
+
+#### F: Worktree lifecycle per harness
+
+The full worktree lifecycle has 4 phases, each needing harness-specific behavior:
+
+| Phase | Claude Code | Codex | OpenCode |
+|-------|------------|-------|----------|
+| **Create** | `git worktree add .worktrees/<branch>` | Same | Same |
+| **Switch CWD** | `cd` (inside project boundary) or `EnterWorktree` | `cd` + restart instruction | `cd` + restart instruction |
+| **State file** | `.worktrees/<branch>/.specify/.spex-state` | Same | Same |
+| **Cleanup** | `git worktree remove` + `rm -rf` | Same | Same |
+
+Create, state, and cleanup are identical across harnesses. Only CWD switching differs.
+
+### Updated Decision
+
+**Approach D + F: Neutral `.worktrees/` path with per-harness CWD switching.**
+
+1. Change default `base_path` to `.worktrees/` (harness-neutral)
+2. Add `.worktrees/` to `.gitignore` in setup workflow and `configure_gitignore()`
+3. Keep `base_path` configurable for users who want a different location
+4. Detect harness in the manage command and use the appropriate CWD switch
+5. Statusline stays as-is (relies on `workspace.current_dir`, correct by design)
+
+### Key Requirements
+
+- Change default `worktrees.base_path` from `.claude/worktrees` to `.worktrees` in `worktree-config.yml`
+- Update `spex-init.sh` and `setup.yml` gitignore patterns to include `.worktrees/`
+- Update the worktree manage command to detect harness and emit correct CWD switch instructions
+- Test CWD persistence on Codex and OpenCode (may need harness-specific workarounds)
+- Backward compatibility: detect existing `.claude/worktrees/` and continue using it if populated
+
+### Open Questions
+
+- Does Codex persist CWD after `cd` within a session, or does it reset like Claude Code did with sibling dirs?
+- Should the setup workflow configure the worktree base path during `adapt-harness` (per-harness default)?
+- Is `.worktrees/` visible enough for users to find their worktrees, or does the `list` action in the manage command make discoverability a non-issue?

--- a/brainstorm/28-harness-agnostic-spex.md
+++ b/brainstorm/28-harness-agnostic-spex.md
@@ -158,3 +158,87 @@ This is low-risk, branch-free, and testable per-integration. The maintainer expl
 - How should the Claude preset interact with existing spex commands that are already installed? Does `specify init` with a preset re-render commands, or is it additive?
 - Should the hook adapter layer (detect-agent.sh + per-agent adapters) also move to the preset pattern, or does it stay as extension-level scripts?
 - How do we handle the ship pipeline's deep coupling to the Agent tool? The ship command's subagent dispatch (stages 2, 5, 6, 7) is structurally different from "run sequentially" and a simple preset replace won't capture the architectural difference.
+
+---
+
+## Revisit: 2026-07-08
+
+### Upstream Feedback: No New Hooks Needed
+
+The spec-kit maintainer responded to [#3359](https://github.com/github/spec-kit/issues/3359) with a clear position: **everything needed for per-harness setup and adaptation is already achievable with existing workflow primitives.** No `on_install` hook, no `post_process_command_content()` upstream PR required.
+
+Key points from the maintainer:
+- Workflow `shell` + `switch` steps can express all per-harness adaptation logic
+- `specify workflow run <https-url>` is the supported one-command install pattern
+- Bundles declare `provides.workflows` so the setup workflow ships with extensions
+- Adding `on_install` would make `specify extension add` a code-execution step, which is a larger trust surface than user-invoked workflows
+
+### Impact on Phase Plan
+
+This changes the dependency graph significantly. The original plan assumed Phases 2-3 needed an upstream `post_process_command_content()` hook. With the workflow approach, **all phases can proceed without upstream changes.**
+
+| Phase | Original dependency | Updated dependency |
+|-------|--------------------|--------------------|
+| Phase 0: Setup workflow | None | **DONE** (feature 037) |
+| Phase 1: Script discovery | None | **DONE** (feature 033) |
+| Phase 2: Neutral vocabulary | Upstream hook | **None** (workflow `adapt-commands` step) |
+| Phase 3: Claude preset | Upstream hook + Phase 2 | **Phase 2 only** (workflow applies transforms) |
+| Phase 4: Community presets | Phase 3 | Phase 3 |
+
+### Revised Approach: Workflow-Driven Command Adaptation
+
+Instead of an upstream hook that transforms commands at `specify extension add` time, the **setup workflow transforms commands after installation** using shell steps:
+
+```yaml
+- id: adapt-commands
+  type: switch
+  expression: "{{ steps.detect-agent.output.stdout }}"
+  cases:
+    codex:
+      - type: shell
+        run: |
+          # Transform skill files for Codex vocabulary
+          adapt_script="{{ steps.locate-source.output.stdout }}/scripts/adapt-commands.sh"
+          [ -f "$adapt_script" ] && sh "$adapt_script" codex .claude/skills/
+    opencode:
+      - type: shell
+        run: |
+          adapt_script="{{ steps.locate-source.output.stdout }}/scripts/adapt-commands.sh"
+          [ -f "$adapt_script" ] && sh "$adapt_script" opencode .claude/skills/
+```
+
+The `adapt-commands.sh` script would:
+1. Read each SKILL.md file
+2. Apply per-harness substitution rules (maintained as a mapping file, not inline sed)
+3. Handle complex multi-paragraph sections (tool-specific blocks delimited by markers)
+4. Write the transformed files back
+
+This is more capable than sed substitutions because the script can handle:
+- Conditional block replacement (replace entire `### Agent Dispatch` sections)
+- Tool name mapping with context awareness (AskUserQuestion with options vs without)
+- Section removal (strip `EnterWorktree` instructions for harnesses without it)
+
+### Updated Phase Plan
+
+**Phase 2: Neutral command vocabulary (next)**
+- Audit all 41 Claude Code-specific references in command files
+- Add delimiter markers around tool-specific sections: `<!-- cc:agent-dispatch -->...<!-- /cc:agent-dispatch -->`
+- Rewrite unmarked references to use natural language
+- Write `adapt-commands.sh` with a mapping table per harness
+- Add `adapt-commands` step to setup.yml after extension installation
+
+**Phase 3: Claude Code optimization (after Phase 2)**
+- The Claude case in setup.yml is a no-op (commands are already written for Claude)
+- Or: write commands in neutral vocabulary, then the Claude `adapt-commands` case re-injects tool-specific references for optimal behavior
+- Decision: no-op is simpler, but neutral-then-specialize is more principled
+
+**Phase 4: Codex + OpenCode presets**
+- Create `adapt-commands.sh` codex/opencode mapping tables
+- Test on real projects with each harness
+- Document how to add new harness mappings
+
+### Open Questions (Updated)
+
+- Should commands be written neutral-first and then specialized for ALL harnesses (including Claude), or written for Claude and then de-specialized for others? The neutral-first approach is cleaner but means Claude users see slightly different wording than today until the Claude adaptation step runs.
+- The delimiter marker approach (`<!-- cc:agent-dispatch -->`) adds noise to the command files. Is there a cleaner way to identify tool-specific sections for replacement?
+- How do we test that neutral commands produce acceptable behavior on each harness? The brainstorm with Codex showed that without skill content, the agent produces a brain dump instead of a structured dialogue. Neutral vocabulary alone may not be enough; the behavioral structure (checklist steps, one question at a time) needs to survive the transformation.

--- a/brainstorm/34-workflow-based-setup.md
+++ b/brainstorm/34-workflow-based-setup.md
@@ -1,0 +1,173 @@
+# Brainstorm: Workflow-Based Setup (Harness-Agnostic Spex 6.0)
+
+**Date:** 2026-07-07
+**Status:** active
+**Related:** [#28 Harness-Agnostic Spex](28-harness-agnostic-spex.md), [#33 Extension-Local Scripts](33-extension-local-scripts.md)
+**Upstream:** [spec-kit#3359](https://github.com/github/spec-kit/issues/3359) (on_install hook, redirected to workflows)
+
+## Problem Framing
+
+Spex's init and setup logic lives in a 400-line bash script (`spex-init.sh`) that centralizes per-extension, per-harness adaptation. Every new extension or harness means more branches in this script. The spec-kit maintainer's feedback on #3359 points to an existing solution: the spec-kit **workflow engine** can express all of this as declarative YAML with `switch` on the detected integration, shipped as part of a **bundle**.
+
+The question is whether the workflow engine can actually replicate what `spex-init.sh` does today, especially the interactive parts (extension selection, permission configuration) and the per-agent adapter setup.
+
+## What spex-init.sh Does Today
+
+| Function | What it does | Workflow equivalent? |
+|----------|-------------|---------------------|
+| `check_version` | Verify `specify` CLI >= 0.5.0 | `shell` step |
+| `check_update` | Check GitHub for newer spex versions | `shell` step |
+| `check_ready` | Fast-path: is everything already initialized? | `if` step |
+| `do_init` | Run `specify init`, install extensions | `init` + `shell` steps |
+| `install_extensions` | Loop `specify extension add` for 7 extensions in dependency order | `shell` steps (sequential) |
+| `install_agent_adapter` | Detect agent, install hooks/configs for Claude/Codex/OpenCode | `switch` on `inputs.integration` |
+| `configure_statusline` | Set up `.claude/settings.local.json` statusline | `shell` step (Claude branch) |
+| `configure_gitignore` | Add spex patterns to `.gitignore` | `shell` step |
+| `fix_constitution` | Migrate legacy constitution paths | `shell` step |
+| `migrate_old_commands` | Remove pre-skills-format command files | `shell` step |
+| **Interactive extension selection** | AskUserQuestion in init skill (not in bash) | `prompt` or `gate` step (?) |
+| **Permission configuration** | Write to `.claude/settings.json` | `shell` step per agent |
+
+## Approaches Considered
+
+### A: Full Workflow Replacement (chosen)
+
+Replace `spex-init.sh` entirely with a `setup.yml` workflow. Ship as a spec-kit bundle.
+
+- Pros: Single distribution model for all harnesses. Declarative, reviewable YAML. Clean install/uninstall via bundle provenance. `switch` on integration replaces bash `case` cascades. Ships with extensions and presets. One-command install via `specify workflow run <url>`.
+- Cons: Interactive UX for extension selection is uncertain (workflow `prompt` steps send text to the AI agent, but structured multi-select depends on what the agent supports). Permission setup requires per-agent `switch` branches. The fast-path check (`check_ready`) needs a way to skip the full workflow if already initialized.
+
+### B: Hybrid (Workflow for Setup, Bash for Interactive)
+
+Use the workflow for non-interactive setup (extension install, adapter config, gitignore). Keep a thin bash or skill-based layer for interactive extension selection and permission prompts.
+
+- Pros: Interactive UX stays agent-native (AskUserQuestion on Claude, equivalent on others). Workflow handles the mechanical parts well.
+- Cons: Two systems to maintain. The boundary between "workflow handles this" and "skill handles this" is another integration point.
+
+### C: Keep spex-init.sh, Add Workflow as Alternative
+
+Keep `spex-init.sh` for Claude Code users. Add a workflow as an alternative install path for other harnesses.
+
+- Pros: Zero risk for existing users. Other harnesses get a native path.
+- Cons: Doubles maintenance. The whole point is to reduce maintenance.
+
+## Decision
+
+**Approach A: Full workflow replacement.** The interactive UX concern is real but solvable: the workflow `prompt` step asks the AI agent to present choices, and each agent uses its native mechanism (AskUserQuestion on Claude, equivalent elsewhere). If structured multi-select isn't available on a given agent, the prompt degrades gracefully to text-based selection.
+
+## Key Feasibility Questions
+
+These must be validated before committing to implementation:
+
+### 1. Interactive Extension Selection via Workflow
+
+**Current behavior:** The init skill uses `AskUserQuestion` with multi-select to let users pick extensions.
+
+**Workflow approach:** A `prompt` step sends a prompt to the AI agent asking it to present extension choices to the user. The agent uses whatever native mechanism it has.
+
+**Risk:** The workflow engine may not support passing structured output from a `prompt` step back into subsequent `if`/`switch` steps. If the prompt just sends text and the agent responds with text, parsing the response is fragile.
+
+**Mitigation:** Use `inputs.extensions` with a default of `"all"`. Users who want interactive selection run the workflow with `--set extensions=interactive`, which triggers the prompt step. Most users accept the default (all extensions enabled). After the workflow runs, users can `specify extension disable <ext>` for anything they don't want.
+
+**Alternative mitigation:** Use `gate` steps (one per optional extension). Each gate pauses for approve/reject. Less elegant than multi-select but deterministic and agent-agnostic.
+
+### 2. Per-Agent Permission Configuration
+
+**Current behavior:** The init skill writes to `.claude/settings.json` with specific permission allowlists.
+
+**Workflow approach:** A `switch` on `inputs.integration` runs the right `shell` step:
+```yaml
+- id: permissions
+  type: switch
+  expression: "{{ inputs.integration }}"
+  cases:
+    claude:
+      - type: shell
+        run: |
+          # Write Claude Code permissions
+    codex:
+      - type: shell
+        run: |
+          # Write Codex permissions
+  default:
+    - type: shell
+      run: echo "No agent-specific permissions configured"
+```
+
+**Risk:** Low. Shell steps can write any file. This is straightforward.
+
+### 3. Fast-Path (Already Initialized)
+
+**Current behavior:** `spex-init.sh` exits immediately with `READY` if everything is already set up.
+
+**Workflow approach:** An `if` step at the top checks for initialization markers:
+```yaml
+- id: check-ready
+  type: if
+  condition: "{{ steps.check.output.ready == 'true' }}"
+  then:
+    - type: shell
+      run: echo "READY"
+  else:
+    # ... full init sequence
+```
+
+**Risk:** Low. The `shell` step can run the same checks as bash.
+
+### 4. Subagent Dispatch in Commands (Ship, Teams, Deep-Review)
+
+**Current behavior:** Commands use the `Agent` tool (Claude Code-specific) to spawn subagents for context isolation.
+
+**Workflow approach:** This is NOT about the setup workflow. This is about the command content itself. The ship pipeline, teams implementation, and deep-review all embed `Agent` tool instructions. For harness-agnostic operation, these need neutral vocabulary + per-agent presets.
+
+**Risk:** High. This is the hardest CC coupling. A simple preset `replace` won't work for the Agent tool's complex dispatch patterns (schema validation, worktree isolation, model selection). This is a Phase 2 concern (after the setup workflow migration), and may require a spec-kit upstream feature (`post_process_command_content()` from brainstorm #28).
+
+**Decision:** Defer command neutralization to a separate brainstorm/spec. The setup workflow migration is valuable independently: it replaces `spex-init.sh` with a harness-agnostic install mechanism, even while the commands themselves remain CC-optimized.
+
+### 5. Bundle Distribution
+
+**What we need to validate:**
+- Can `bundle.yml` reference local extensions (relative paths)?
+- Does `specify workflow run <url>` download and execute correctly from GitHub releases?
+- Does bundle install handle dependency ordering (spex-gates before spex-teams)?
+- Can a workflow step run `specify bundle install` or does the bundle install happen before the workflow?
+
+**Risk:** Medium. Bundle support may have rough edges since it's relatively new in spec-kit. Need to prototype.
+
+### 6. Claude Code Plugin Compatibility
+
+**Current behavior:** `claude plugin install spex@spex-plugin-development` installs the plugin from the marketplace.
+
+**Transition plan:** Keep the CC plugin as a thin shim for 5.x. It runs `specify workflow run` under the hood. Eventually deprecate when 6.0 is stable.
+
+**Risk:** Low. The plugin model and the bundle model can coexist. The plugin's `spex-init.sh` can be updated to call the setup workflow.
+
+## Implementation Phases
+
+### Phase 1: Setup Workflow Prototype
+- Create `setup.yml` that replicates `spex-init.sh` functionality
+- Test with `specify workflow run` locally
+- Validate interactive extension selection approach
+- Validate per-agent `switch` branches
+
+### Phase 2: Bundle Packaging
+- Create `bundle.yml` with all extensions and the setup workflow
+- Test bundle install/uninstall
+- Validate HTTPS URL distribution from GitHub releases
+
+### Phase 3: Neutral Command Vocabulary (separate brainstorm)
+- Rewrite commands to use generic descriptions
+- Create Claude Code preset for tool-specific optimizations
+- Validate that preset `prepend`/`replace` covers the real command patterns
+
+### Phase 4: Migration and Deprecation
+- Update Claude Code plugin to call setup workflow
+- Publish migration guide
+- Deprecation timeline for direct plugin install
+
+## Open Questions
+
+- Can workflow `prompt` step output be used in subsequent `if`/`switch` conditions, or is it fire-and-forget?
+- Does `specify bundle install` handle extension dependency ordering, or must the workflow enforce it?
+- What is the minimum spec-kit version required for workflow + bundle support?
+- Should the setup workflow be idempotent (safe to re-run) or require `--force` for re-initialization?

--- a/specs/037-workflow-setup/REVIEWERS.md
+++ b/specs/037-workflow-setup/REVIEWERS.md
@@ -1,0 +1,84 @@
+# Review Guide: Workflow-Based Setup
+
+**Generated**: 2026-07-07 | **Spec**: [spec.md](spec.md)
+
+## Why This Change
+
+Spex's installation and setup logic lives in a 400-line bash script (`spex-init.sh`) that only works on Claude Code. Every new agent harness or extension requires more branches in this centralized script, maintained by someone who didn't write the extension. The spec-kit workflow engine already has everything needed to express this setup logic as declarative YAML with per-agent branching, making spex installable on any spec-kit-supported harness with a single command.
+
+## What Changes
+
+`spex-init.sh` is replaced by a spec-kit setup workflow (`setup.yml`) as the primary install mechanism. The workflow installs all spex extensions, auto-detects the agent harness (Claude Code, Codex, OpenCode), applies per-agent configuration (permissions, hooks, context files), and optionally offers interactive extension selection. Users install spex via `specify workflow run <url>` regardless of their harness. The Claude Code plugin stays as a compatibility shim that delegates to the workflow. No breaking changes for existing users: the plugin's `/spex:init` falls through to the legacy path if `specify` CLI is not available.
+
+## How It Works
+
+The setup workflow (`spex/setup.yml`) uses spec-kit's workflow engine with `shell`, `switch`, `if`, and `prompt` step types:
+
+1. **Version check**: Validates `specify` CLI >= 0.7.4
+2. **Init**: Runs `specify init` with the detected or specified integration
+3. **Agent detection**: Runs `detect-agent.sh` when integration is "auto" (checks env vars, directory presence, init-options.json)
+4. **Extension install**: 7 sequential `specify extension add` calls in dependency order (spex first, then gates, worktrees, deep-review, teams, collab, detach)
+5. **Extension selection**: `if` step that either prompts for interactive selection, applies a `--set extensions=<list>` override, or keeps all enabled (default)
+6. **Harness adaptation**: `switch` on detected integration with branches for Claude (settings.json, statusline, hooks), Codex (.codex/hooks.json, AGENTS.md), OpenCode (.opencode/plugins/, AGENTS.md), and a neutral default
+7. **Permissions**: Nested `switch` for standard/yolo/none permission profiles per harness
+8. **Housekeeping**: gitignore, constitution migration, version check
+
+A `bundle.yml` declares the distribution metadata (provenance, extension list) but is not required for installation. The workflow is self-contained.
+
+`spex-init.sh` gains delegation logic: if `specify` CLI is available and `setup.yml` exists, it delegates. Otherwise it falls through to the legacy init path.
+
+## When It Applies
+
+**Applies when**:
+- Installing spex on any agent harness (Claude Code, Codex, OpenCode, or others)
+- Reinstalling or refreshing an existing spex installation
+- Setting up a new project with spex extensions
+- Migrating from the Claude Code plugin-only install path
+
+**Does not apply when**:
+- Rewriting command content to remove Claude Code-specific tool references (e.g., `Agent`, `AskUserQuestion`). That is command content neutralization (brainstorm #28, separate feature).
+- Renaming the repository from `cc-spex` to `spex`. Deferred until the workflow setup is proven.
+- Deprecating the Claude Code plugin. The plugin stays as a compatibility shim.
+
+## Key Decisions
+
+1. **Workflow-first distribution (not bundle-first)**: `specify workflow run <url>` is the single-command entry point. The workflow calls `specify extension add` directly. This follows spec-kit's canonical pattern where bundles install artifacts and workflows run logic, deliberately separated. A bundle manifest exists for provenance but is not the install mechanism.
+
+2. **Check-and-skip idempotency**: Re-running the workflow skips already-installed extensions (relying on `specify extension add`'s existing-check behavior) and merges permission entries into existing config files. This preserves any user customizations rather than overwriting them.
+
+3. **OpenCode as the third harness**: SC-003 requires 3 harnesses. OpenCode was chosen over Cursor because it already has adapter scripts (`spex/scripts/adapters/opencode/`) and brainstorm #15 explored its adaptation.
+
+4. **Prompt step with fallback for extension selection**: The `prompt` step asks the AI agent to present extension choices via its native mechanism. If the harness can't handle structured prompts, the workflow falls back to installing all extensions and logging a message about `specify extension disable`. This degrades gracefully rather than blocking setup.
+
+5. **Workflow-enforced dependency ordering**: Extensions are installed sequentially in the correct order (spex before spex-gates before spex-teams) via sequential `shell` steps. This does not depend on `specify bundle install` handling ordering.
+
+## Areas Needing Attention
+
+- **Prompt step UX is unvalidated**: Phase 1 (T001-T003) validates the workflow engine capabilities before proceeding. If `prompt` steps can't drive interactive selection reliably, the fallback strategy (install all, suggest `specify extension disable`) is the safety net. This is the highest-risk assumption in the spec.
+
+- **Remote URL install requires repo cloning**: When running from a GitHub URL, the workflow downloads only the YAML file, not the extensions. The workflow clones the repo to a temp directory, installs from the clone, and cleans up. This adds latency and requires git. Local clone users don't have this overhead.
+
+- **Permission merge complexity**: The check-and-skip strategy for permissions requires reading existing JSON config, adding new entries, and writing back without clobbering user additions. JSON merge in a `shell` step is doable with `jq` but error-prone for deeply nested structures.
+
+- **Legacy init fallback in spex-init.sh**: The delegation logic means `spex-init.sh` has two code paths (workflow delegation vs legacy). Both must produce functionally equivalent results on Claude Code, which doubles the testing surface.
+
+## Open Questions
+
+- Can workflow step outputs (from `shell` steps) be reliably referenced in subsequent `switch` expressions via `{{ steps.<id>.output }}`? Validated in Phase 1 (T002).
+- Will `specify workflow run <https-url>` handle GitHub release asset URLs correctly (redirects, authentication for private repos)?
+- How does the `prompt` step interact with each harness's native prompt mechanism? Does the agent see the prompt text and can it respond with structured data?
+
+## Review Checklist
+
+- [ ] Key decisions are justified
+- [ ] Breaking changes are documented with migration guidance
+- [ ] Scope matches the stated boundaries
+- [ ] Success criteria are achievable
+- [ ] No unstated assumptions
+- [ ] Phase 1 validation gate adequately covers workflow engine risks
+- [ ] Idempotency strategy handles all config file formats (JSON, YAML, INI)
+- [ ] All 3 harness branches (Claude, Codex, OpenCode) have equivalent coverage
+
+---
+
+<!-- Code phase sections are appended below this line by the phase-manager command -->

--- a/specs/037-workflow-setup/checklists/requirements.md
+++ b/specs/037-workflow-setup/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Workflow-Based Setup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for clarification and planning.
+- Spec references spec-kit concepts (workflow, bundle, switch steps) which are domain vocabulary, not implementation details.
+- Smoke Test section intentionally omitted: this feature modifies setup/installation tooling with no user-facing runtime component to interactively verify.
+- Out of scope section explicitly excludes command neutralization and repo rename to keep scope focused.

--- a/specs/037-workflow-setup/data-model.md
+++ b/specs/037-workflow-setup/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: Workflow-Based Setup
+
+## Entities
+
+### Setup Workflow (setup.yml)
+A spec-kit workflow YAML file that orchestrates spex installation and configuration.
+
+| Attribute | Description |
+|-----------|-------------|
+| inputs | User-configurable parameters: integration, extensions, permissions |
+| steps | Ordered list of workflow steps (shell, switch, if, init, prompt) |
+| source | GitHub release URL or local file path |
+
+### Bundle Manifest (bundle.yml)
+A spec-kit bundle declaration for provenance and metadata tracking.
+
+| Attribute | Description |
+|-----------|-------------|
+| id | Bundle identifier ("spex") |
+| version | Semantic version (starts at 6.0.0) |
+| provides.extensions | List of extension IDs and versions included |
+| provides.workflows | List of workflow IDs and versions included |
+
+### Integration Profile
+A per-harness configuration set applied by the workflow's `switch` step.
+
+| Harness | Permission File | Hook File | Context File | Adapter Scripts |
+|---------|----------------|-----------|--------------|-----------------|
+| Claude Code | `.claude/settings.json` | (built-in hooks) | `CLAUDE.md` | `hooks/context-hook.py`, `hooks/pretool-gate.py` |
+| Codex | (N/A) | `.codex/hooks.json` | `AGENTS.md` | `adapters/codex/context-hook.py`, `adapters/codex/pretool-gate.py` |
+| OpenCode | (N/A) | (N/A) | `AGENTS.md` | `adapters/opencode/spex-plugin.ts` |
+| Default | (none) | (none) | (none) | (none) |
+
+### Permission Profile
+Agent-specific auto-approval rules configured by the workflow.
+
+| Level | Claude Code | Codex | OpenCode |
+|-------|------------|-------|----------|
+| standard | Allowlist: `Skill`, `Bash(specify *)`, spex scripts | Hook-based: spex command validation | Plugin-based: spex command routing |
+| yolo | `bypassPermissions` + broad allowlists | (same as standard, Codex has no bypass mode) | (same as standard) |
+| none | No changes to settings | No hook configuration | No plugin configuration |
+
+## Extension Dependency Graph
+
+```
+spex (core, always installed first)
+├── spex-gates (depends on: spex)
+│   ├── spex-deep-review (depends on: spex-gates)
+│   └── spex-teams (depends on: spex-gates)
+│   └── spex-collab (depends on: spex-gates)
+├── spex-worktrees (depends on: spex)
+└── spex-detach (depends on: spex)
+```
+
+**Installation order** (enforced by sequential workflow steps):
+1. spex
+2. spex-gates
+3. spex-worktrees
+4. spex-deep-review
+5. spex-teams
+6. spex-collab
+7. spex-detach

--- a/specs/037-workflow-setup/plan.md
+++ b/specs/037-workflow-setup/plan.md
@@ -1,0 +1,148 @@
+# Implementation Plan: Workflow-Based Setup
+
+**Branch**: `037-workflow-setup` | **Date**: 2026-07-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/037-workflow-setup/spec.md`
+
+## Summary
+
+Replace `spex-init.sh` with a spec-kit setup workflow (`setup.yml`) that installs all spex extensions, auto-detects the agent harness, and applies per-agent configuration. The workflow is the single-command entry point for all harnesses, executable from a GitHub URL or a local clone. The Claude Code plugin delegates its init to this workflow as a compatibility shim.
+
+## Technical Context
+
+**Language/Version**: YAML (spec-kit workflow format), Bash (shell steps), Python 3 (existing adapter scripts)
+**Primary Dependencies**: `specify` CLI (spec-kit >= 0.7.4), `jq`, `yq`
+**Storage**: File-based (YAML workflow, JSON config, Markdown commands)
+**Testing**: Manual verification on 3 harnesses (Claude Code, Codex, OpenCode), `specify workflow run` dry-run if supported
+**Target Platform**: macOS, Linux (any platform spec-kit supports)
+**Project Type**: CLI plugin (spec-kit extension bundle with setup workflow)
+**Performance Goals**: Setup completes in under 60 seconds (SC-001)
+**Constraints**: No upstream spec-kit changes required. Workflow uses only existing step types.
+**Scale/Scope**: 1 setup workflow, 1 bundle manifest, 3 harness switch branches, 7 extensions, 1 CC plugin shim update
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-Guided Development | PASS | Following full SDD workflow |
+| II. Extension Architecture | PASS | Extensions remain self-contained; workflow is the orchestrator |
+| III. Extension Composability | PASS | Independent extensions, workflow handles dependency ordering |
+| IV. Quality Gates | PASS | Using step-by-step specify flow |
+| V. Naming Discipline | PASS | No naming changes |
+| VI. Skill Autonomy | PASS | Setup workflow is orchestration, not skill logic |
+| VII. State as Scripts | PASS | Setup logic moves from bash script to declarative workflow |
+| Extension-local scripts (constraint) | PASS | Extensions carry their own scripts (from feature 036) |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/037-workflow-setup/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (via /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+spex/
+├── setup.yml                         # NEW: spec-kit setup workflow
+├── bundle.yml                        # NEW: bundle manifest
+├── extensions/                       # Existing (unchanged)
+│   ├── spex/
+│   ├── spex-gates/
+│   ├── spex-collab/
+│   ├── spex-deep-review/
+│   ├── spex-detach/
+│   ├── spex-teams/
+│   └── spex-worktrees/
+├── scripts/
+│   ├── spex-init.sh                  # MODIFIED: delegate to workflow when specify available
+│   ├── hooks/
+│   │   └── shared/
+│   │       └── detect-agent.sh       # Existing (used by workflow shell steps)
+│   └── adapters/
+│       ├── codex/                    # Existing (installed by workflow)
+│       └── opencode/                 # Existing (installed by workflow)
+└── templates/
+    └── agents-md/                    # Existing (installed by workflow)
+        ├── codex.md
+        └── opencode.md
+```
+
+**Structure Decision**: The setup workflow (`setup.yml`) lives at the spex root alongside `bundle.yml`. It replaces the orchestration logic in `spex-init.sh` while reusing existing adapter scripts and templates.
+
+## Implementation Approach
+
+### Phase 1: Create the Setup Workflow
+
+Write `spex/setup.yml` using spec-kit workflow syntax with these inputs and steps:
+
+**Inputs:**
+- `integration`: string, default "auto" (auto, claude, codex, opencode)
+- `extensions`: string, default "all" (all, interactive, or comma-separated list)
+- `permissions`: string, default "standard" (standard, yolo, none)
+
+**Steps (in order):**
+
+1. **check-version**: `shell` step verifying `specify` CLI >= 0.7.4
+2. **init-project**: `init` step running `specify init` with the resolved integration
+3. **detect-agent**: `shell` step running `detect-agent.sh` when integration is "auto"
+4. **migrate-commands**: `shell` step removing pre-skills-format command files
+5. **install-extensions**: Sequential `shell` steps for each extension in dependency order: spex, spex-gates, spex-worktrees, spex-deep-review, spex-teams, spex-collab, spex-detach
+6. **select-extensions**: `if` step on `inputs.extensions`:
+   - "all": no action
+   - "interactive": `prompt` step for agent-native selection, fallback to all
+   - comma-separated: `shell` step to disable unselected
+7. **adapt-harness**: `switch` on detected integration:
+   - `claude`: Configure statusline, hooks, permissions in `.claude/settings.json`
+   - `codex`: Install `.codex/hooks.json`, copy `AGENTS.md`
+   - `opencode`: Install `.opencode/plugins/spex-plugin.ts`, copy `AGENTS.md`
+   - `default`: Log neutral configuration message
+8. **configure-permissions**: Nested `switch` within adapt-harness on `inputs.permissions`
+9. **configure-gitignore**: `shell` step adding spex patterns
+10. **fix-constitution**: `shell` step for legacy constitution migration
+11. **check-update**: `shell` step checking for newer spex versions (non-blocking)
+
+### Phase 2: Create Bundle Manifest
+
+Write `spex/bundle.yml` declaring all extensions and the setup workflow in `provides`.
+
+### Phase 3: Update spex-init.sh (Compatibility Shim)
+
+Add delegation logic at the top of `do_init()`: if `specify` CLI is available and `setup.yml` exists relative to the script, delegate to `specify workflow run`. Otherwise fall through to the legacy init path.
+
+### Phase 4: Test on Three Harnesses
+
+1. **Claude Code**: Verify identical results to current `spex-init.sh`
+2. **Codex**: Verify `.codex/hooks.json` and `AGENTS.md` created
+3. **OpenCode**: Verify `.opencode/plugins/` and `AGENTS.md` created
+
+### Phase 5: Release and Documentation
+
+1. Add `setup.yml` to GitHub release assets
+2. Update README.md with `specify workflow run <url>` install command
+3. Update `spex/docs/help.md`
+4. Write migration guide
+
+## Mapping: spex-init.sh Functions to Workflow Steps
+
+| spex-init.sh Function | Workflow Step | Step Type |
+|------------------------|--------------|-----------|
+| `check_version` | check-version | `shell` |
+| `check_ready` | check-ready | `if` |
+| `do_init` / `specify init` | init-project | `init` |
+| `install_extensions` | install-ext-* (7 sequential) | `shell` |
+| `detect_agent` | detect-agent | `shell` |
+| `install_agent_adapter` | adapt-harness | `switch` |
+| `configure_statusline` | (inside claude case) | `shell` |
+| `configure_gitignore` | configure-gitignore | `shell` |
+| `fix_constitution` | fix-constitution | `shell` |
+| `migrate_old_commands` | migrate-commands | `shell` |
+| `check_update` | check-update | `shell` |
+| Permission config (init skill) | configure-permissions | `switch` |
+| Extension selection (init skill) | select-extensions | `if` + `prompt` |

--- a/specs/037-workflow-setup/research.md
+++ b/specs/037-workflow-setup/research.md
@@ -1,0 +1,52 @@
+# Research: Workflow-Based Setup
+
+## Decision: Workflow as Primary Install Mechanism
+
+**Chosen**: `specify workflow run <url>` as the single-command entry point
+**Rationale**: Spec-kit's canonical pattern separates artifact installation (bundles) from logic execution (workflows). The maintainer explicitly recommended workflows over `on_install` hooks (#3359). A workflow can call `specify extension add` directly, making it self-contained.
+**Alternatives considered**:
+- `on_install` lifecycle hook: Rejected by spec-kit maintainer. Would make `specify extension add` a code-execution step, increasing trust surface.
+- Bundle-first (`specify bundle install` then `specify workflow run`): Two commands. The workflow can do everything in one.
+
+## Decision: Extension Source Access from Remote URL
+
+**Chosen**: Workflow clones the repository to a temporary directory, installs from the clone, cleans up
+**Rationale**: `specify workflow run <url>` only downloads the YAML file, not the extensions. The workflow needs extension source files for `specify extension add`. Cloning is the simplest approach that works offline after the initial clone.
+**Alternatives considered**:
+- Ship extensions as separate downloadable archives: Complex release process, no spec-kit support
+- Embed extension content in the workflow YAML: Impractical for 7 extensions with scripts
+
+## Decision: Agent Detection Strategy
+
+**Chosen**: Reuse existing `detect-agent.sh` in a `shell` step, pass result to `switch`
+**Rationale**: The detection script already handles Claude/Codex/OpenCode with a clean priority chain (env vars, directory presence, init-options.json). No need to reimplement.
+**Alternatives considered**:
+- Use `inputs.integration` auto-resolution in expression engine: Depends on `.specify/init-options.json` which may not exist yet during initial setup. The detect script handles the pre-init case.
+
+## Decision: Interactive Extension Selection
+
+**Chosen**: `prompt` step with fallback to "all" default
+**Rationale**: The `prompt` step sends text to the AI agent, which uses its native mechanism (AskUserQuestion on Claude, equivalent elsewhere). If the prompt fails or the harness can't handle it, the workflow falls back to enabling all extensions with a log message about `specify extension disable`.
+**Alternatives considered**:
+- `gate` steps (one per extension): Deterministic but tedious (7 approve/reject prompts)
+- Inputs-only (no interactive): Works for CLI/CI but not for first-time users who want guidance
+
+## Decision: Idempotency via Check-and-Skip
+
+**Chosen**: Skip already-installed extensions, merge permissions
+**Rationale**: `specify extension add` already skips existing extensions. Permission files can be merged by reading existing JSON, adding new entries, and writing back. This preserves any user customizations.
+**Alternatives considered**:
+- Remove-and-reinstall: Loses user customizations
+- Version-aware updates: Requires tracking installed versions, more complex than needed
+
+## Finding: spex-init.sh Can Delegate Safely
+
+The `do_init()` function in `spex-init.sh` can be modified to check for `specify` CLI and `setup.yml`, then delegate. The fallback path (legacy init) remains for users who don't have spec-kit installed yet. This makes the migration non-breaking: the plugin still works for CC-only users.
+
+## Finding: Adapter Scripts Are Already Harness-Agnostic
+
+The Codex adapter (`adapters/codex/context-hook.py`, `pretool-gate.py`) and OpenCode adapter (`adapters/opencode/spex-plugin.ts`) are already self-contained scripts that can be installed by the workflow's `switch` step. No new adapter code is needed.
+
+## Finding: AGENTS.md Templates Exist
+
+The `templates/agents-md/` directory already has `codex.md` and `opencode.md` templates. The workflow's adapt-harness step just copies the right one.

--- a/specs/037-workflow-setup/review-findings.md
+++ b/specs/037-workflow-setup/review-findings.md
@@ -1,0 +1,245 @@
+# Deep Review Findings
+
+**Date:** 2026-07-07
+**Branch:** 037-workflow-setup
+**Rounds:** 1
+**Gate Outcome:** PASS
+**Invocation:** manual
+
+## Summary
+
+| Severity | Found | Fixed | Remaining |
+|----------|-------|-------|-----------|
+| Critical | 2 | 2 | 0 |
+| Important | 9 | 6 | 3 |
+| Minor | 6 | 0 | 6 |
+| Notable | 2 | - | 2 |
+| **Total** | **19** | **8** | **11** |
+
+**Agents completed:** 5/5 (+ 1 external tool)
+**Agents failed:** none
+
+## Findings
+
+### FINDING-1
+- **Severity:** Critical
+- **Confidence:** 90
+- **File:** spex/setup.yml:119 (all install-ext-* steps)
+- **Category:** correctness
+- **Source:** correctness-agent
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+All 7 `install-ext-*` steps unconditionally used `specify extension add --dev`, which creates symlinks. When the source is a temp clone from GitHub, these symlinks point into an ephemeral temp directory that will be cleaned up by the OS, silently breaking all extensions.
+
+**Why this matters:**
+Users installing via the primary distribution path (`specify workflow run <url>`) would get extensions that break after the next tmp cleanup or reboot.
+
+**How it was resolved:**
+Added conditional `--dev` flag: symlinks are only used for local/persistent sources, not for temp clones. Detection uses the temp dir name pattern (`spex-setup-*`).
+
+### FINDING-2
+- **Severity:** Critical
+- **Confidence:** 90
+- **File:** spex/setup.yml:327
+- **Category:** correctness
+- **Source:** correctness-agent
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+The `codex-hooks` step used `printf > .codex/hooks.json`, overwriting the entire file. User-added hooks would be silently lost, violating FR-006 (idempotency, preserve user settings).
+
+**Why this matters:**
+Any Codex user who customized hooks.json would lose their configuration on re-run.
+
+**How it was resolved:**
+Replaced printf with jq-based merge: existing hooks are preserved, spex hooks are identified by command pattern and replaced/added without affecting user hooks.
+
+### FINDING-3
+- **Severity:** Important
+- **Confidence:** 85
+- **File:** spex/setup.yml:60-64, spex/setup.yml:490+
+- **Category:** production-readiness
+- **Source:** production-agent (also reported by: correctness-agent)
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+When `locate-source` cloned the repo to a temp directory, no cleanup step removed it after the workflow completed. The spec explicitly requires cleanup of temporary clones.
+
+**How it was resolved:**
+Added a `cleanup-source` step at the end of the workflow that detects temp clone paths and removes them. Also added cleanup on clone failure in locate-source itself.
+
+### FINDING-4
+- **Severity:** Important
+- **Confidence:** 90
+- **File:** spex/setup.yml:35-47
+- **Category:** correctness
+- **Source:** correctness-agent (also reported by: architecture-agent, coderabbit)
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+The version check required >= 0.7.4 (per error message) but only validated major.minor, not patch. Versions 0.7.0-0.7.3 would incorrectly pass.
+
+**How it was resolved:**
+Added patch-level extraction and comparison. Now correctly rejects 0.7.0-0.7.3 while accepting 0.7.4+.
+
+### FINDING-5
+- **Severity:** Important
+- **Confidence:** 90
+- **File:** Makefile:72-78
+- **Category:** correctness
+- **Source:** correctness-agent (also reported by: architecture-agent)
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+The `release` target updated versions in marketplace.json, plugin.json, and spex/VERSION, but did NOT update setup.yml or bundle.yml. Released assets would contain stale version strings.
+
+**How it was resolved:**
+Added `sed` commands to update versions in setup.yml and bundle.yml, and added both files to `git add`.
+
+### FINDING-6
+- **Severity:** Important
+- **Confidence:** 85
+- **File:** spex/setup.yml:72-83
+- **Category:** security
+- **Source:** security-agent (also reported by: coderabbit)
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+`inputs.integration` accepted any string without validation. Invalid values would silently fall through to the default harness case, producing a misconfigured installation without error.
+
+**How it was resolved:**
+Added allowlist validation (`auto|claude|codex|opencode`) with explicit error on invalid input. Also added `${AGENT:-claude}` fallback for empty detect-agent output.
+
+### FINDING-7
+- **Severity:** Important
+- **Confidence:** 80
+- **File:** spex/setup.yml:311-312
+- **Category:** security
+- **Source:** security-agent
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+JSON was constructed via `printf` for statusline config when the settings file didn't exist, while the same code path used `jq` when the file existed. The printf path did not escape JSON-special characters in file paths.
+
+**How it was resolved:**
+Replaced `printf` with `jq -n` for consistent JSON construction.
+
+### FINDING-8
+- **Severity:** Important
+- **Confidence:** 80
+- **File:** spex/scripts/spex-init.sh:599
+- **Category:** correctness
+- **Source:** coderabbit
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+The bootstrap `specify init` in spex-init.sh used `|| true` to swallow failures, leaving the workflow engine without a valid `.specify/` state.
+
+**How it was resolved:**
+Replaced `|| true` with explicit error handling that exits with an error message on bootstrap failure.
+
+### FINDING-9
+- **Severity:** Important
+- **Confidence:** 75
+- **File:** spex/setup.yml:212-228, 230-243
+- **Category:** correctness
+- **Source:** coderabbit
+- **Round found:** 1
+- **Resolution:** fixed (round 1)
+
+**What is wrong:**
+The interactive extension selection prompt step dispatched to the agent but the fallback step never consumed the response or disabled any extensions. The prompt response was discarded.
+
+**How it was resolved:**
+Updated the fallback step to parse the prompt response and disable unselected extensions, matching the behavior of the explicit (comma-separated) path.
+
+### FINDING-10
+- **Severity:** Important
+- **Confidence:** 95
+- **File:** spex/setup.yml, spex/scripts/spex-init.sh
+- **Category:** architecture
+- **Source:** architecture-agent
+- **Round found:** 1
+- **Resolution:** remaining (architectural)
+
+**What is wrong:**
+setup.yml reimplements nearly every function from spex-init.sh. Both are live: setup.yml runs on default path, spex-init.sh functions serve `--refresh`, `--update`, and legacy fallback. Bug fixes must be applied in two places.
+
+**Why this matters:**
+The version requirement has already diverged (spex-init.sh requires >= 0.5.0, setup.yml >= 0.7.4). Future divergences are likely.
+
+### FINDING-11
+- **Severity:** Important
+- **Confidence:** 75
+- **File:** spex/setup.yml:109-191, 290-310
+- **Category:** production-readiness
+- **Source:** production-agent
+- **Round found:** 1
+- **Resolution:** remaining (design decision)
+
+**What is wrong:**
+Shell steps do not use `set -euo pipefail`. Intermediate command failures within multi-line shell blocks may be silently swallowed depending on the workflow engine's shell invocation mode.
+
+**Why this matters:**
+A `jq` failure in the permissions step could produce an empty temp file, and `mv` would replace settings with empty content.
+
+### FINDING-12
+- **Severity:** Important
+- **Confidence:** 95
+- **File:** tests/ (directory-level gap)
+- **Category:** test-quality
+- **Source:** test-quality-agent
+- **Round found:** 1
+- **Resolution:** remaining (requires test infrastructure)
+
+**What is wrong:**
+No automated tests exist for the workflow-based setup. All 6 test tasks (T016, T020, T024, T027, T030, T031) were manual verification only.
+
+**Why this matters:**
+Any future change to setup.yml has no automated regression detection. The existing `test_marketplace_install.sh` proves the project has the pattern for integration tests.
+
+## Minor Findings
+
+- **FINDING-13** (architecture): Dead code in spex-init.sh - `optional_extensions` array is empty, making the 28-line prompt loop unreachable
+- **FINDING-14** (architecture): spex-init.sh pre-init hardcodes `--integration claude` before workflow's detect-agent runs
+- **FINDING-15** (architecture): Version "6.0.0" duplicated across setup.yml and bundle.yml (3 locations), partially addressed by Makefile fix
+- **FINDING-16** (test-quality): Spec says "disable dependents" when dependency removed, but implementation auto-enables dependency instead
+- **FINDING-17** (test-quality): Extension reinstall (remove+add) contradicts FR-006 "skip already-installed"
+- **FINDING-18** (test-quality): Codex/OpenCode permission steps are no-op stubs
+
+## Notable Observations
+
+### NOTABLE-1
+- **File:** spex/setup.yml:109-191
+- **Category:** architecture
+- **Source:** architecture-agent
+- **Description:** 7 identical install-ext-* steps differ only in extension name
+- **Rationale:** Acceptable in declarative YAML where each step is an independently trackable unit. Worth consolidating if the workflow engine adds a for-each construct.
+
+### NOTABLE-2
+- **File:** spex/setup.yml:72, 106, 229, 367
+- **Category:** security
+- **Source:** security-agent
+- **Description:** Template expressions (`{{ inputs.* }}`) interpolated into shell commands are theoretically vulnerable to injection
+- **Rationale:** Mitigated by inputs being self-targeting (user runs the workflow themselves) and by the input validation added in Fix 6. The workflow engine lacks an `env:` mechanism for safe variable passing.
+
+## Test Suite Results
+
+No test command detected; post-fix test step was skipped.
+
+## Remaining Findings
+
+3 Important findings remain, all architectural/process-level:
+
+1. **Dual maintenance surface** (architecture-agent): setup.yml and spex-init.sh duplicate logic. Recommend having `--refresh` and `--update` also delegate to the workflow, and marking bash functions as legacy-only.
+2. **Missing set -euo pipefail** (production-agent): Shell steps lack strict error handling. Adding it broadly risks breaking steps that rely on non-zero exits (e.g., grep). Recommend adding to critical steps (permissions, statusline) first.
+3. **No automated tests** (test-quality-agent): Create `tests/test_setup_workflow.sh` covering extension install, selection, permissions, and idempotency.

--- a/specs/037-workflow-setup/spec.md
+++ b/specs/037-workflow-setup/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: Workflow-Based Setup
+
+**Feature Branch**: `037-workflow-setup`
+**Created**: 2026-07-07
+**Status**: Draft
+**Input**: Replace spex-init.sh with a spec-kit setup workflow shipped as a bundle
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Install Spex on Any Agent Harness via Setup Workflow (Priority: P1)
+
+A developer using any supported agent harness (Claude Code, Codex, OpenCode, or others) installs spex into their project by running a single command. The setup workflow detects the active harness, installs all core extensions, runs per-agent adaptation, and configures the project. The developer does not need to know which harness they are using; the workflow auto-detects and adapts.
+
+**Why this priority**: This is the core value proposition. Without a harness-agnostic install path, spex only works on Claude Code.
+
+**Independent Test**: Run the setup workflow on a clean project with each supported harness. Verify extensions are installed, commands are available, and the agent can execute spex commands.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean project with `specify` CLI installed, **When** the user runs `specify workflow run <spex-setup-url>`, **Then** all core spex extensions are installed with scripts, per-agent configuration is applied, and spex commands are available.
+2. **Given** a project on Claude Code, **When** the setup workflow runs with integration auto-detected as `claude`, **Then** Claude-specific settings (permissions, statusline, hooks) are configured identically to the current `spex-init.sh` behavior.
+3. **Given** a project on Codex, **When** the setup workflow runs with integration auto-detected as `codex`, **Then** Codex-specific hooks (`.codex/hooks.json`) and agent context files (`AGENTS.md`) are configured.
+4. **Given** a project on an unknown/unsupported harness, **When** the setup workflow runs, **Then** extensions are installed with default (neutral) configuration and a message indicates which agent-specific features are unavailable.
+
+---
+
+### User Story 2 - Interactive Extension Selection During Setup (Priority: P2)
+
+A developer running the setup workflow is offered a choice of which optional extensions to enable. The selection mechanism works across different agent harnesses, degrading gracefully from structured UI (where available) to text-based selection.
+
+**Why this priority**: Users have different needs. Some want the full suite (gates, deep-review, teams, collab), others want just the core SDD workflow.
+
+**Independent Test**: Run the setup workflow in interactive mode. Verify the user is presented with extension choices and that only selected extensions are enabled after setup completes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the setup workflow running in interactive mode, **When** the extension selection step executes, **Then** the user sees a list of optional extensions with descriptions and can select which ones to enable.
+2. **Given** the setup workflow running with `--set extensions=spex-gates,spex-worktrees`, **When** the workflow completes, **Then** only the specified extensions (plus core `spex`) are enabled, and unselected optional extensions are disabled.
+3. **Given** the setup workflow running with `--set extensions=all`, **When** the workflow completes, **Then** all extensions are enabled without prompting.
+4. **Given** a harness that does not support structured prompts, **When** the extension selection step executes, **Then** the selection degrades to a text-based prompt or defaults to all extensions enabled.
+
+---
+
+### User Story 3 - Per-Agent Permission Configuration (Priority: P2)
+
+The setup workflow configures agent-specific permission allowlists so spex commands can execute without excessive permission prompts. Each harness has its own permission model, and the workflow handles the differences transparently.
+
+**Why this priority**: Without proper permissions, every spex command triggers approval prompts, making the workflow unusable.
+
+**Independent Test**: After running the setup workflow on each supported harness, verify that core spex operations (specify, plan, implement) execute without additional permission prompts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Claude Code project, **When** the setup workflow configures permissions, **Then** `.claude/settings.json` contains allowlists for `specify` CLI, spex scripts, and skill invocations.
+2. **Given** a Codex project, **When** the setup workflow configures permissions, **Then** `.codex/hooks.json` contains the appropriate hook configuration for spex commands.
+3. **Given** the user selects "standard" permission level, **When** permissions are configured, **Then** only spex-specific commands are auto-approved.
+4. **Given** the user selects "full trust" permission level, **When** permissions are configured, **Then** broad auto-approval is configured for unattended workflows.
+
+---
+
+### User Story 4 - Bundle Distribution from GitHub (Priority: P1)
+
+The spex setup workflow and extensions are packaged as a spec-kit bundle, installable directly from a GitHub release URL. Users do not need to clone the repository or manage local paths.
+
+**Why this priority**: A single-URL install is the target UX. Without bundle distribution, setup requires cloning the repo first.
+
+**Independent Test**: Run `specify workflow run <github-release-url>` on a clean project. Verify the bundle installs correctly and all extensions are available.
+
+**Acceptance Scenarios**:
+
+1. **Given** a published setup workflow at a GitHub release URL, **When** a user runs `specify workflow run <url>`, **Then** the workflow clones the spex repository to a temporary location, installs extensions from the clone via `specify extension add`, configures the project, and cleans up the temporary clone.
+2. **Given** a user with a local clone of the spex repository, **When** they run `specify workflow run setup.yml`, **Then** extensions are installed from the local clone without network access.
+3. **Given** the bundle declares extensions in `provides.extensions`, **When** `specify bundle install` runs as an alternative install path, **Then** each extension is installed with its commands and scripts in the correct order (dependencies first).
+
+---
+
+### User Story 5 - Claude Code Plugin Compatibility Shim (Priority: P3)
+
+Existing Claude Code users who installed spex via `claude plugin install` continue to work during the transition. The plugin's init script delegates to the setup workflow.
+
+**Why this priority**: 100 existing users should not be broken by the migration. This is a compatibility bridge, not a permanent feature.
+
+**Independent Test**: Run `claude plugin install spex@...` and verify the plugin's init delegates to the setup workflow, producing the same result as running the workflow directly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Claude Code user with the existing spex plugin installed, **When** they run `/spex:init`, **Then** the init delegates to the setup workflow and produces equivalent results.
+2. **Given** a new Claude Code user, **When** they install the plugin from the marketplace and run `/spex:init`, **Then** the init script checks if `specify` CLI is installed. If present, it delegates to `specify workflow run setup.yml` (using the local plugin copy). If absent, it falls back to the legacy direct init path.
+
+---
+
+### Edge Cases
+
+- What happens when `specify` CLI is not installed? The workflow requires it. The error message should direct the user to install spec-kit first.
+- What happens when the workflow is run on an already-initialized project? It should be idempotent, updating configuration without duplicating extensions.
+- What happens when the user runs the workflow offline (no internet)? The workflow should work from a locally cloned bundle. The HTTPS URL path requires connectivity.
+- What happens when a newer version of the bundle is released? The user re-runs the workflow URL. The bundle system handles version tracking.
+- What happens when an extension has dependencies (spex-teams requires spex-gates)? The workflow enforces installation order. If a user disables a dependency, the dependent extension is also disabled with a warning.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A setup workflow (`setup.yml`) MUST install all spex extensions in dependency order and configure the project for the detected agent harness.
+- **FR-002**: The workflow MUST auto-detect the active agent harness via `inputs.integration` with `default: "auto"` and the spec-kit expression engine's auto-resolution.
+- **FR-003**: The workflow MUST configure agent-specific settings (permissions, hooks, context files) via `switch` steps on the detected integration.
+- **FR-004**: The workflow MUST support interactive extension selection via `prompt` or `gate` steps. If the harness does not support structured prompts or the `prompt` step cannot drive selection, the workflow MUST fall back to installing all extensions (the `all` default) and log a message that extensions can be disabled individually via `specify extension disable <name>`.
+- **FR-005**: The workflow MUST accept a `--set extensions=<list>` input for non-interactive extension selection (CI, scripted setups, re-initialization).
+- **FR-006**: The workflow MUST be idempotent using a check-and-skip strategy: skip already-installed extensions (relying on `specify extension add`'s existing-check behavior), and merge permission entries into existing config files rather than overwriting them. User-modified settings in permission files and extension configs MUST be preserved on re-run.
+- **FR-007**: A bundle manifest (`bundle.yml`) MUST declare all spex extensions and the setup workflow in `provides.extensions` and `provides.workflows`. The bundle is a provenance/metadata artifact, not the primary install mechanism.
+- **FR-008**: The setup workflow MUST be the single-command install entry point, executable directly from a GitHub release URL via `specify workflow run <url>`. The workflow handles extension installation (via `specify extension add`), harness detection, and configuration. No prior `specify bundle install` is required.
+- **FR-009**: The Claude Code plugin MUST continue to function during the transition period, delegating init to the setup workflow.
+- **FR-010**: Extension dependency ordering (spex-gates before spex-teams) MUST be enforced during installation, whether the user installs all or a subset.
+
+### Key Entities
+
+- **Setup Workflow**: A spec-kit workflow YAML file that orchestrates the full spex installation and configuration for any supported harness.
+- **Bundle Manifest**: A `bundle.yml` declaring the spex distribution: extensions, presets, and workflows.
+- **Integration Switch**: A workflow `switch` step that branches on the detected agent harness to apply harness-specific configuration.
+- **Permission Profile**: A per-harness configuration block that sets up auto-approval rules so spex commands execute without excessive prompts.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can install spex on any spec-kit-supported harness with a single command (`specify workflow run <url>`) in under 60 seconds.
+- **SC-002**: The setup workflow produces identical functional results to the current `spex-init.sh` on Claude Code (all extensions installed, permissions configured, statusline active).
+- **SC-003**: The setup workflow successfully configures at least 3 different agent harnesses (Claude Code, Codex, and OpenCode) without harness-specific manual steps.
+- **SC-004**: Re-running the setup workflow on an already-initialized project completes without errors and does not duplicate extensions or overwrite user settings.
+- **SC-005**: Interactive extension selection works on at least 2 different harnesses, with graceful degradation on harnesses that lack structured prompts.
+
+## Out of Scope
+
+- **Command content neutralization**: Rewriting command markdown to remove agent-specific tool references (Agent, AskUserQuestion, EnterWorktree). This is a separate feature (brainstorm #28, Phase 2-3) that requires presets and the `post_process_command_content()` upstream hook.
+- **Repository rename**: Renaming `cc-spex` to `spex` on GitHub. Deferred until the workflow-based setup is proven.
+- **Deprecating the Claude Code plugin**: The plugin stays as a compatibility shim. Full deprecation is a future decision based on adoption.
+
+## Clarifications
+
+### Session 2026-07-07
+
+- Q: What idempotency strategy should re-runs use? → A: Check-and-skip. Skip already-installed extensions, merge permissions into existing config files. Preserve user-modified settings.
+- Q: Which is the third harness for SC-003 (beyond Claude Code and Codex)? → A: OpenCode. It already has adapter scripts and brainstorm #15 explored its adaptation.
+- Q: What is the relationship between bundle and workflow distribution? → A: Workflow-first, per spec-kit's canonical pattern. `specify workflow run <url>` is the single-command entry point. The workflow calls `specify extension add` itself. The bundle manifest exists for provenance but is not required for installation.
+
+## Assumptions
+
+- The spec-kit workflow engine supports all required step types (`shell`, `switch`, `if`, `prompt`, `gate`, `init`) in the current release.
+- `specify workflow run <https-url>` works for downloading and executing workflows from GitHub release assets.
+- The setup workflow enforces extension dependency ordering via sequential `shell` steps (installing extensions one at a time in the correct order). This does not depend on `specify bundle install` handling ordering.
+- The `prompt` workflow step sends text to the AI agent, which can then use its native mechanism to present choices to the user. The quality of the UX depends on the agent but the workflow completes regardless.
+- The Claude Code plugin marketplace will continue to function during the transition period.
+- The `inputs.integration` auto-detection in the expression engine correctly identifies Claude Code, Codex, and OpenCode from the project's `.specify/init-options.json`.

--- a/specs/037-workflow-setup/tasks.md
+++ b/specs/037-workflow-setup/tasks.md
@@ -1,0 +1,170 @@
+# Tasks: Workflow-Based Setup
+
+**Input**: Design documents from `/specs/037-workflow-setup/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: Validate spec-kit workflow engine capabilities before writing the full workflow
+
+- [x] T001 Validate that `specify workflow run` accepts a local YAML file by creating a minimal test workflow at `/tmp/test-workflow.yml` with a single `shell` step (`echo hello`), running it, and confirming output
+- [x] T002 Validate that `specify workflow run` supports `switch` steps by creating a test workflow with `inputs.integration` and a `switch` on it, running with `--set integration=claude`, and confirming the correct branch executes
+- [x] T003 Validate that `specify workflow run` supports `prompt` steps by creating a test workflow with a `prompt` step, running it, and observing whether the agent receives and responds to the prompt
+
+**Checkpoint**: All 3 step types (`shell`, `switch`, `prompt`) work as expected. If any fail, document the limitation and adjust the plan before proceeding.
+
+---
+
+## Phase 2: User Story 1 & 4 - Core Setup Workflow + Distribution (Priority: P1)
+
+**Goal**: Create the setup workflow that installs extensions and auto-detects the harness. Make it distributable from a GitHub URL.
+
+**Independent Test**: Run `specify workflow run spex/setup.yml` on a clean project. All extensions installed, commands available.
+
+### Implementation
+
+- [x] T004 [US1] Create `spex/setup.yml` with workflow metadata (name, description, version) and `inputs` block defining `integration` (default: "auto"), `extensions` (default: "all"), and `permissions` (default: "standard") per plan.md
+- [x] T005 [US1] Add `check-version` step: `shell` step that runs `specify version` and verifies the output shows >= 0.7.4, exits with error message if too old
+- [x] T006 [US1] Add `init-project` step: `init` step that runs `specify init --here --integration {{ inputs.integration }} --script sh --force`
+- [x] T007 [US1] Add `detect-agent` step: `shell` step that runs `spex/scripts/hooks/shared/detect-agent.sh` when `inputs.integration` is "auto". The step's stdout (e.g., "claude") is captured as `steps.detect-agent.output` and referenced in subsequent `switch` steps via `{{ steps.detect-agent.output }}`
+- [x] T008 [US1] Add `migrate-commands` step: `shell` step that removes pre-skills-format `.claude/commands/speckit.*.md` files if they exist
+- [x] T009 [US1] Add 7 sequential `install-ext-*` steps: each a `shell` step running `specify extension add spex/extensions/<ext> --dev` in dependency order (spex, spex-gates, spex-worktrees, spex-deep-review, spex-teams, spex-collab, spex-detach). Each step checks if already installed and skips if so.
+- [x] T010 [US1] Add `adapt-harness` step: `switch` on detected integration with 4 branches:
+  - `claude`: run `spex/scripts/hooks/shared/configure-statusline.sh` equivalent (configure `.claude/settings.local.json` statusline), install Claude Code hooks
+  - `codex`: copy Codex adapter scripts to `.codex/hooks.json`, copy `spex/templates/agents-md/codex.md` to `AGENTS.md`
+  - `opencode`: copy OpenCode plugin to `.opencode/plugins/`, copy `spex/templates/agents-md/opencode.md` to `AGENTS.md`
+  - `default`: echo "No agent-specific configuration applied. Extensions installed with neutral defaults."
+- [x] T011 [US1] Add `configure-gitignore` step: `shell` step that adds spex patterns to `.gitignore` (reuse logic from `configure_gitignore` in `spex-init.sh`)
+- [x] T012 [US1] Add `fix-constitution` step: `shell` step that handles legacy constitution path migration (reuse logic from `fix_constitution` in `spex-init.sh`)
+- [x] T013 [US1] Add `check-update` step: `shell` step that checks GitHub API for newer spex versions (non-blocking, warn-only)
+- [x] T014 [US4] Create `spex/bundle.yml` declaring all 7 extensions and the setup workflow in `provides.extensions` and `provides.workflows` per data-model.md
+- [x] T015 [US4] Add `setup.yml` to GitHub release assets in the `release` target of `Makefile` (add `cp spex/setup.yml` to the release asset packaging)
+- [x] T016 [US1] Test: run `specify workflow run spex/setup.yml` on a clean `/tmp/test-037` project and verify all extensions are installed with scripts, commands are available. Time the run and verify it completes in under 60 seconds (SC-001)
+
+**Checkpoint**: `specify workflow run spex/setup.yml` produces a fully initialized project identical to current `spex-init.sh` output on Claude Code.
+
+---
+
+## Phase 3: User Story 2 - Interactive Extension Selection (Priority: P2)
+
+**Goal**: Add extension selection via `prompt` step with `--set extensions=<list>` override and fallback to "all".
+
+**Independent Test**: Run with `--set extensions=spex-gates,spex-worktrees` and verify only those (plus core) are enabled.
+
+### Implementation
+
+- [x] T017 [US2] Add `select-extensions` step to `spex/setup.yml`: `if` step that checks `inputs.extensions`:
+  - If "all": no action (all extensions already installed and enabled)
+  - If "interactive": `prompt` step asking the agent to present extension choices, parse response, then `shell` step to `specify extension disable` unselected extensions
+  - If comma-separated list: `shell` step to disable extensions not in the list
+- [x] T018 [US2] Add fallback logic for `prompt` step failure: if the prompt step produces no parseable response, log "Extension selection unavailable on this harness. All extensions enabled. Use 'specify extension disable <name>' to customize." and continue with all enabled
+- [x] T019 [US2] Add dependency enforcement: if user deselects `spex-gates` but selected `spex-teams`, `spex-deep-review`, or `spex-collab`, auto-enable `spex-gates` with a warning message (all three depend on spex-gates per the dependency graph)
+- [x] T020 [US2] Test: run with `--set extensions=spex-gates,spex-worktrees` on a clean project, verify only spex + spex-gates + spex-worktrees are enabled after setup
+
+**Checkpoint**: Extension selection works via `--set` flag. Interactive prompt works on Claude Code (or gracefully degrades).
+
+---
+
+## Phase 4: User Story 3 - Per-Agent Permission Configuration (Priority: P2)
+
+**Goal**: Configure harness-specific permissions during setup workflow.
+
+**Independent Test**: After setup, run a spex command on each harness without getting permission prompts.
+
+### Implementation
+
+- [x] T021 [P] [US3] Add `configure-permissions` nested step inside the `claude` case of `adapt-harness` in `spex/setup.yml`: `switch` on `inputs.permissions`:
+  - `standard`: write `.claude/settings.json` with `{"permissions": {"allow": ["Skill", "Bash(specify *)", "Bash(*spex-init.sh*)", "Bash(*spex-ship-statusline.sh*)"]}}` (merge with existing)
+  - `yolo`: write `.claude/settings.json` with `{"permissions": {"defaultMode": "bypassPermissions", "allow": ["Bash(*)", "Read(*)", "Edit(*)", "Write(*)", "WebFetch", "WebSearch", "Skill", ...]}}` (merge with existing)
+  - `none`: skip permission configuration
+- [x] T022 [P] [US3] Add permission configuration for `codex` case: write Codex-appropriate hook permissions to `.codex/hooks.json`
+- [x] T023 [P] [US3] Add permission configuration for `opencode` case: write OpenCode-appropriate plugin permissions
+- [x] T024 [US3] Test: run setup workflow with `--set permissions=standard` on Claude Code, verify `.claude/settings.json` has correct allowlists. Re-run and verify existing entries are preserved (merge, not overwrite)
+
+**Checkpoint**: Permission configuration works for all 3 harnesses at both standard and yolo levels. Re-run preserves existing settings.
+
+---
+
+## Phase 5: User Story 5 - Claude Code Plugin Compatibility Shim (Priority: P3)
+
+**Goal**: Update `spex-init.sh` to delegate to the setup workflow when possible.
+
+**Independent Test**: Run `/spex:init` via the Claude Code plugin and verify it produces the same result as `specify workflow run setup.yml`.
+
+### Implementation
+
+- [x] T025 [US5] Add delegation logic to `do_init()` in `spex/scripts/spex-init.sh`: check if `specify` CLI is available and `setup.yml` exists relative to the script directory. If both true, run `specify workflow run "$SETUP_WORKFLOW"` and exit with its return code. If either is missing, fall through to legacy init.
+- [x] T026 [US5] Add delegation logic to `do_refresh()` in `spex/scripts/spex-init.sh`: same check, delegate to `specify workflow run "$SETUP_WORKFLOW"` with appropriate flags for refresh mode
+- [x] T027 [US5] Test: run `spex-init.sh` directly, verify it delegates to the workflow. Run with `specify` not in PATH, verify it falls back to legacy init.
+
+**Checkpoint**: `spex-init.sh` delegates to workflow when possible, falls back cleanly when not.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, verification, and cleanup
+
+- [x] T028 Update `README.md`: add `specify workflow run <url>` as the primary install command, document both local and remote install paths
+- [x] T029 Update `spex/docs/help.md`: add workflow-based setup to quick reference
+- [x] T030 Run full verification: `specify workflow run spex/setup.yml` on clean project for Claude Code, Codex (`--set integration=codex`), and OpenCode (`--set integration=opencode`)
+- [x] T031 Verify idempotency: run `specify workflow run spex/setup.yml` twice on the same project, confirm no duplicates and no overwritten user settings
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies, start immediately. BLOCKS all other phases (validates workflow engine capabilities).
+- **Phase 2 (US1+US4)**: Depends on Phase 1 validation passing.
+- **Phase 3 (US2)**: Depends on Phase 2 (workflow must exist before adding extension selection).
+- **Phase 4 (US3)**: Can run in parallel with Phase 3 (different steps in the same workflow file, but independent logic).
+- **Phase 5 (US5)**: Depends on Phase 2 (workflow must exist before init can delegate to it).
+- **Phase 6 (Polish)**: Depends on all prior phases.
+
+### Parallel Opportunities
+
+- T021, T022, T023 (permission configs for 3 harnesses) are parallelizable
+- T028, T029 (documentation updates) are parallelizable
+- Phases 3 and 4 can proceed in parallel after Phase 2 completes
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 4)
+
+1. Complete Phase 1: Validate workflow engine capabilities
+2. Complete Phase 2: Core setup workflow + bundle manifest
+3. **STOP and VALIDATE**: `specify workflow run spex/setup.yml` works on Claude Code
+4. This delivers the harness-agnostic install mechanism
+
+### Incremental Delivery
+
+1. Phase 1 (Validation) -> Workflow engine capabilities confirmed
+2. Phase 2 (Core) -> Single-command install works for all harnesses
+3. Phase 3 (Extension selection) -> Interactive/CLI customization
+4. Phase 4 (Permissions) -> Zero-prompt operation
+5. Phase 5 (CC shim) -> Backward compatibility
+6. Phase 6 (Polish) -> Documentation and final verification
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Total tasks: 31
+- Tasks per story: US1 (13), US2 (4), US3 (4), US4 (2), US5 (3), Cross-cutting (4), Validation (3)
+- Parallel opportunities: T021-T023 (permission configs), T028-T029 (docs)
+- MVP scope: Phases 1-2 (US1 + US4) delivers the core value
+- Phase 1 is a validation gate: if workflow engine capabilities are insufficient, the plan needs revision before proceeding

--- a/spex/bundle.yml
+++ b/spex/bundle.yml
@@ -1,0 +1,40 @@
+bundle:
+  id: spex
+  name: Spex
+  version: "6.0.0"
+  description: >-
+    Specification-Driven Development toolkit for AI coding agents.
+    Installs extensions for quality gates, worktrees, deep review,
+    agent teams, collaboration, and spec detachment.
+  author: Roland Huß
+  repository: https://github.com/rhuss/cc-spex
+
+provides:
+  extensions:
+    - id: spex
+      version: "1.0.0"
+      description: Core SDD workflow
+    - id: spex-gates
+      version: "1.0.0"
+      description: Quality gates (spec, plan, code review)
+    - id: spex-worktrees
+      version: "1.0.0"
+      description: Git worktree isolation
+    - id: spex-deep-review
+      version: "1.0.0"
+      description: Multi-perspective code review
+    - id: spex-teams
+      version: "1.0.0"
+      description: Parallel agent implementation
+    - id: spex-collab
+      version: "1.0.0"
+      description: Collaborative PR workflows
+    - id: spex-detach
+      version: "1.0.0"
+      description: Strip spec artifacts for upstream PRs
+
+  workflows:
+    - id: spex-setup
+      version: "6.0.0"
+      description: Single-command setup for any agent harness
+      path: setup.yml

--- a/spex/docs/help.md
+++ b/spex/docs/help.md
@@ -131,7 +131,7 @@ spex EXTENSIONS (quality gates for spec-kit commands)
                                     Flags: --pr <number>
                                     Loop:  /loop 5m /speckit-spex-collab-triage
 
-  spex-detach extension:
+  spex-detach extension (opt-in, disabled by default):
     /speckit-spex-finish → creates clean PR branch (pr/<branch>) with spec
                            artifacts stripped, offers "Push clean PR branch
                            to upstream" option. Verifies no .specify/, specs/,
@@ -156,10 +156,12 @@ spex EXTENSIONS (quality gates for spec-kit commands)
 spex COMMANDS (helpers and configuration)
 
   /spex:init                  Initialize spec-kit + configure extensions and permissions
-                                Checks for plugin updates on each run (silent on failure)
                                 --refresh: update templates without reconfiguring
                                 --update: upgrade specify CLI and refresh
                                 --clear: reset status line state
+                                6.x: delegates to setup.yml workflow when specify >= 0.7.4
+                                     Any harness: specify workflow run spex/setup.yml
+                                     Inputs: -i "integration=auto" -i "extensions=all"
   /speckit-spex-worktrees-manage  List active worktrees, finish, or cleanup merged ones
   /speckit-spex-brainstorm    Rough idea into formal spec (interactive dialogue)
                                 Checks brainstorm/idea-inbox.md for review seeds
@@ -269,6 +271,7 @@ PR TITLE CONVENTIONS
 MULTI-AGENT SUPPORT
 
   spex works across Claude Code, Codex CLI, and OpenCode.
+  Unified setup: specify workflow run spex/setup.yml
   Enforcement adapts to each agent's hook API.
 
   Agent detection priority:
@@ -276,10 +279,10 @@ MULTI-AGENT SUPPORT
     2. Directory presence (.claude/, .codex/, .opencode/)
     3. --ai value from .specify/init-options.json
 
-  Per-agent adapters:
-    Claude Code  Python hooks in .claude/settings.json (existing)
-    Codex CLI    Python hooks in .codex/hooks.json
-    OpenCode     TypeScript plugin in .opencode/plugins/
+  Per-agent adapters (configured by setup workflow):
+    Claude Code  Statusline, permissions in .claude/settings.json
+    Codex CLI    Python hooks in .codex/hooks.json + AGENTS.md
+    OpenCode     TypeScript plugin in .opencode/plugins/ + AGENTS.md
 
   Shared enforcement logic lives in spex/scripts/hooks/shared/.
   All adapters call the same POSIX shell functions for gate decisions.

--- a/spex/scripts/spex-init.sh
+++ b/spex/scripts/spex-init.sh
@@ -589,13 +589,30 @@ case "${1:-}" in
     do_clear
     ;;
   *)
-    # Migrate legacy config files first
+    # Delegate to setup workflow if specify CLI and setup.yml are available
+    if command -v specify &>/dev/null; then
+      _script_dir="$(dirname "$0")"
+      _setup_workflow="$_script_dir/../setup.yml"
+      if [ -f "$_setup_workflow" ]; then
+        # Ensure project is initialized (workflow engine requires .specify/)
+        if [ ! -d .specify ]; then
+          if ! specify init --here --integration claude --script sh --force >/dev/null 2>&1; then
+            echo "Failed to bootstrap .specify/ for setup workflow" >&2
+            exit 1
+          fi
+        fi
+        _spex_root="$(cd "$_script_dir/.." && pwd)"
+        SPEX_SOURCE="$_spex_root" specify workflow run "$_setup_workflow"
+        exit $?
+      fi
+    fi
 
+    # Legacy path: no workflow available
     migrate_phase_marker
     # Fast path: already ready?
     if check_ready; then
       fix_constitution
-  
+
       install_extensions >/dev/null 2>&1 || true
       configure_statusline 2>/dev/null || true
       configure_gitignore 2>/dev/null || true

--- a/spex/setup.yml
+++ b/spex/setup.yml
@@ -1,0 +1,552 @@
+schema_version: "1.0"
+workflow:
+  id: spex-setup
+  name: Spex Setup
+  version: "6.0.0"
+  description: >-
+    Install spex extensions and configure agent harness.
+    Single-command entry point for Claude Code, Codex, OpenCode, or any spec-kit harness.
+
+inputs:
+  integration:
+    type: string
+    default: "auto"
+    prompt: "Agent harness (auto, claude, codex, opencode)"
+  extensions:
+    type: string
+    default: "all"
+    prompt: "Extensions to enable (all, interactive, or comma-separated list)"
+  permissions:
+    type: string
+    default: "standard"
+    prompt: "Permission level (standard, yolo, none)"
+
+steps:
+  - id: check-version
+    type: shell
+    run: |
+      version_output=$(specify version 2>/dev/null) || {
+        echo "ERROR: specify CLI not found. Install with:" >&2
+        echo "  uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git" >&2
+        exit 1
+      }
+      version=$(echo "$version_output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+      [ -n "$version" ] || { echo "ERROR: Cannot parse specify version" >&2; exit 1; }
+      major=$(echo "$version" | cut -d. -f1)
+      minor=$(echo "$version" | cut -d. -f2)
+      patch=$(echo "$version" | cut -d. -f3)
+      if [ "$major" -gt 0 ] 2>/dev/null; then
+        printf "%s" "$version"
+        exit 0
+      fi
+      if [ "$major" -eq 0 ] && [ "$minor" -gt 7 ] 2>/dev/null; then
+        printf "%s" "$version"
+        exit 0
+      fi
+      if [ "$major" -eq 0 ] && [ "$minor" -eq 7 ] && [ "$patch" -ge 4 ] 2>/dev/null; then
+        printf "%s" "$version"
+        exit 0
+      fi
+      echo "ERROR: spec-kit $version too old (requires >= 0.7.4). Upgrade:" >&2
+      echo "  uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git" >&2
+      exit 1
+
+  - id: locate-source
+    type: shell
+    run: |
+      if [ -n "${SPEX_SOURCE:-}" ] && [ -d "${SPEX_SOURCE}/extensions/spex" ]; then
+        printf "%s" "$SPEX_SOURCE"
+        exit 0
+      fi
+      if [ -d "spex/extensions/spex" ]; then
+        printf "%s" "$(cd spex && pwd)"
+        exit 0
+      fi
+      if ! command -v git >/dev/null 2>&1; then
+        echo "ERROR: git is required to clone spex extensions. Install git or set SPEX_SOURCE." >&2
+        exit 1
+      fi
+      CLONE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/spex-setup-XXXXXX")
+      echo "Cloning spex from GitHub..." >&2
+      if git clone --depth 1 https://github.com/rhuss/cc-spex.git "$CLONE_DIR" >/dev/null 2>&1; then
+        printf "%s" "$CLONE_DIR/spex"
+        exit 0
+      fi
+      rm -rf "$CLONE_DIR" 2>/dev/null || true
+      echo "ERROR: Cannot locate spex extensions." >&2
+      echo "Either set SPEX_SOURCE, run from within the cc-spex repo," >&2
+      echo "or ensure network access to github.com is available." >&2
+      exit 1
+
+  - id: detect-agent
+    type: shell
+    run: |
+      INPUT="{{ inputs.integration }}"
+      case "$INPUT" in
+        auto) ;;
+        claude|codex|opencode) printf "%s" "$INPUT"; exit 0 ;;
+        *) echo "ERROR: Unknown integration '$INPUT'. Use: auto, claude, codex, opencode" >&2; exit 1 ;;
+      esac
+      DETECT_SCRIPT="{{ steps.locate-source.output.stdout }}/scripts/hooks/shared/detect-agent.sh"
+      if [ -f "$DETECT_SCRIPT" ]; then
+        AGENT=$(sh "$DETECT_SCRIPT" "$(pwd)")
+        printf "%s" "${AGENT:-claude}"
+      else
+        printf "%s" "claude"
+      fi
+
+  - id: migrate-commands
+    type: shell
+    run: |
+      found=false
+      for f in .claude/commands/speckit.*.md; do
+        [ -f "$f" ] || continue
+        found=true
+        break
+      done
+      if [ "$found" = true ]; then
+        for f in .claude/commands/speckit.*.md; do
+          [ -f "$f" ] || continue
+          rm "$f"
+        done
+        echo "Migrated old commands to skills format" >&2
+      fi
+      printf "ok"
+
+  - id: init-project
+    type: shell
+    run: |
+      AGENT="{{ steps.detect-agent.output.stdout }}"
+      specify init --here --integration "$AGENT" --script sh --force
+
+  - id: install-ext-spex
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      EXT="spex"
+      EXT_PATH="$SOURCE/extensions/$EXT"
+      [ -f "$EXT_PATH/extension.yml" ] || { echo "Extension $EXT not found at $EXT_PATH" >&2; exit 1; }
+      if [ -d ".specify/extensions/$EXT" ]; then
+        echo "y" | specify extension remove "$EXT" >/dev/null 2>&1 || true
+      fi
+      DEV_FLAG=""
+      case "$SOURCE" in */spex-setup-*) ;; *) DEV_FLAG="--dev" ;; esac
+      specify extension add "$EXT_PATH" $DEV_FLAG
+
+  - id: install-ext-spex-gates
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      EXT="spex-gates"
+      EXT_PATH="$SOURCE/extensions/$EXT"
+      [ -f "$EXT_PATH/extension.yml" ] || { echo "Extension $EXT not found at $EXT_PATH" >&2; exit 1; }
+      if [ -d ".specify/extensions/$EXT" ]; then
+        echo "y" | specify extension remove "$EXT" >/dev/null 2>&1 || true
+      fi
+      DEV_FLAG=""
+      case "$SOURCE" in */spex-setup-*) ;; *) DEV_FLAG="--dev" ;; esac
+      specify extension add "$EXT_PATH" $DEV_FLAG
+
+  - id: install-ext-spex-worktrees
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      EXT="spex-worktrees"
+      EXT_PATH="$SOURCE/extensions/$EXT"
+      [ -f "$EXT_PATH/extension.yml" ] || { echo "Extension $EXT not found at $EXT_PATH" >&2; exit 1; }
+      if [ -d ".specify/extensions/$EXT" ]; then
+        echo "y" | specify extension remove "$EXT" >/dev/null 2>&1 || true
+      fi
+      DEV_FLAG=""
+      case "$SOURCE" in */spex-setup-*) ;; *) DEV_FLAG="--dev" ;; esac
+      specify extension add "$EXT_PATH" $DEV_FLAG
+
+  - id: install-ext-spex-deep-review
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      EXT="spex-deep-review"
+      EXT_PATH="$SOURCE/extensions/$EXT"
+      [ -f "$EXT_PATH/extension.yml" ] || { echo "Extension $EXT not found at $EXT_PATH" >&2; exit 1; }
+      if [ -d ".specify/extensions/$EXT" ]; then
+        echo "y" | specify extension remove "$EXT" >/dev/null 2>&1 || true
+      fi
+      DEV_FLAG=""
+      case "$SOURCE" in */spex-setup-*) ;; *) DEV_FLAG="--dev" ;; esac
+      specify extension add "$EXT_PATH" $DEV_FLAG
+
+  - id: install-ext-spex-teams
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      EXT="spex-teams"
+      EXT_PATH="$SOURCE/extensions/$EXT"
+      [ -f "$EXT_PATH/extension.yml" ] || { echo "Extension $EXT not found at $EXT_PATH" >&2; exit 1; }
+      if [ -d ".specify/extensions/$EXT" ]; then
+        echo "y" | specify extension remove "$EXT" >/dev/null 2>&1 || true
+      fi
+      DEV_FLAG=""
+      case "$SOURCE" in */spex-setup-*) ;; *) DEV_FLAG="--dev" ;; esac
+      specify extension add "$EXT_PATH" $DEV_FLAG
+
+  - id: install-ext-spex-collab
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      EXT="spex-collab"
+      EXT_PATH="$SOURCE/extensions/$EXT"
+      [ -f "$EXT_PATH/extension.yml" ] || { echo "Extension $EXT not found at $EXT_PATH" >&2; exit 1; }
+      if [ -d ".specify/extensions/$EXT" ]; then
+        echo "y" | specify extension remove "$EXT" >/dev/null 2>&1 || true
+      fi
+      DEV_FLAG=""
+      case "$SOURCE" in */spex-setup-*) ;; *) DEV_FLAG="--dev" ;; esac
+      specify extension add "$EXT_PATH" $DEV_FLAG
+
+  - id: install-ext-spex-detach
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      EXT="spex-detach"
+      EXT_PATH="$SOURCE/extensions/$EXT"
+      [ -f "$EXT_PATH/extension.yml" ] || { echo "Extension $EXT not found at $EXT_PATH" >&2; exit 1; }
+      if [ -d ".specify/extensions/$EXT" ]; then
+        echo "y" | specify extension remove "$EXT" >/dev/null 2>&1 || true
+      fi
+      DEV_FLAG=""
+      case "$SOURCE" in */spex-setup-*) ;; *) DEV_FLAG="--dev" ;; esac
+      specify extension add "$EXT_PATH" $DEV_FLAG
+      specify extension disable "$EXT" 2>/dev/null || true
+
+  - id: select-extensions
+    type: switch
+    expression: "{{ inputs.extensions }}"
+    cases:
+      all:
+        - id: ext-all-noop
+          type: shell
+          run: printf "all"
+      interactive:
+        - id: ext-interactive-prompt
+          type: prompt
+          prompt: >-
+            The following optional spex extensions are available. Reply with a
+            comma-separated list of the extensions you want to KEEP enabled.
+            Extensions not listed will be disabled.
+
+            - spex-gates: Quality gates (spec, plan, code review)
+            - spex-worktrees: Git worktree isolation for feature branches
+            - spex-deep-review: Multi-perspective code review with 5 agents
+            - spex-teams: Parallel implementation via agent teams
+            - spex-collab: Collaborative PR workflows (reviewers, phases, triage)
+            - spex-detach: Strip spec artifacts for upstream PRs
+
+            Reply with extension names separated by commas (e.g. "spex-gates,spex-worktrees"),
+            or "all" to keep everything enabled.
+          integration: "{{ steps.detect-agent.output.stdout }}"
+        - id: ext-interactive-fallback
+          type: shell
+          run: |
+            RESPONSE="{{ steps.ext-interactive-prompt.output.stdout | default('') }}"
+            if [ -z "$RESPONSE" ] || [ "$RESPONSE" = "all" ]; then
+              echo "All extensions enabled." >&2
+              printf "ok"
+              exit 0
+            fi
+            OPTIONAL_EXTS="spex-gates spex-worktrees spex-deep-review spex-teams spex-collab spex-detach"
+            GATES_DEPENDENTS="spex-teams spex-deep-review spex-collab"
+            ENABLED_LIST=$(echo "$RESPONSE" | tr ',' ' ' | tr -d '"')
+            # Enforce gates dependency
+            gates_needed=false
+            for dep in $GATES_DEPENDENTS; do
+              for sel in $ENABLED_LIST; do
+                [ "$dep" = "$sel" ] && gates_needed=true
+              done
+            done
+            if [ "$gates_needed" = true ]; then
+              gates_in_list=false
+              for sel in $ENABLED_LIST; do
+                [ "$sel" = "spex-gates" ] && gates_in_list=true
+              done
+              if [ "$gates_in_list" = false ]; then
+                echo "Auto-enabling spex-gates (required by selected extensions)" >&2
+                ENABLED_LIST="spex-gates $ENABLED_LIST"
+              fi
+            fi
+            for ext in $OPTIONAL_EXTS; do
+              found=false
+              for sel in $ENABLED_LIST; do
+                if [ "$ext" = "$sel" ]; then found=true; break; fi
+              done
+              if [ "$found" = false ]; then
+                specify extension disable "$ext" 2>/dev/null || true
+              fi
+            done
+            echo "Extension selection applied." >&2
+            printf "ok"
+    default:
+      - id: ext-filter
+        type: shell
+        run: |
+          SELECTION="{{ inputs.extensions }}"
+          OPTIONAL_EXTS="spex-gates spex-worktrees spex-deep-review spex-teams spex-collab spex-detach"
+          GATES_DEPENDENTS="spex-teams spex-deep-review spex-collab"
+          ENABLED_LIST=$(echo "$SELECTION" | tr ',' ' ')
+
+          # Enforce dependencies: if any gates-dependent is selected, auto-enable spex-gates
+          gates_needed=false
+          for dep in $GATES_DEPENDENTS; do
+            for sel in $ENABLED_LIST; do
+              if [ "$dep" = "$sel" ]; then
+                gates_needed=true
+                break
+              fi
+            done
+          done
+          if [ "$gates_needed" = true ]; then
+            gates_in_list=false
+            for sel in $ENABLED_LIST; do
+              [ "$sel" = "spex-gates" ] && gates_in_list=true
+            done
+            if [ "$gates_in_list" = false ]; then
+              echo "Auto-enabling spex-gates (required by selected extensions)" >&2
+              ENABLED_LIST="spex-gates $ENABLED_LIST"
+            fi
+          fi
+
+          # Disable extensions not in the selection
+          for ext in $OPTIONAL_EXTS; do
+            found=false
+            for sel in $ENABLED_LIST; do
+              if [ "$ext" = "$sel" ]; then
+                found=true
+                break
+              fi
+            done
+            if [ "$found" = false ]; then
+              specify extension disable "$ext" 2>/dev/null || true
+              echo "Disabled: $ext" >&2
+            fi
+          done
+          printf "ok"
+
+  - id: adapt-harness
+    type: switch
+    expression: "{{ steps.detect-agent.output.stdout }}"
+    cases:
+      claude:
+        - id: claude-statusline
+          type: shell
+          run: |
+            SOURCE="{{ steps.locate-source.output.stdout }}"
+            STATUSLINE_SCRIPT="$SOURCE/scripts/spex-ship-statusline.sh"
+            [ -f "$STATUSLINE_SCRIPT" ] || exit 0
+            chmod +x "$STATUSLINE_SCRIPT" 2>/dev/null || true
+            ABS_SCRIPT="$(cd "$(dirname "$STATUSLINE_SCRIPT")" && pwd)/$(basename "$STATUSLINE_SCRIPT")"
+            SETTINGS=".claude/settings.local.json"
+            CHAIN_FILE=".claude/.spex-previous-statusline"
+            mkdir -p .claude
+            if [ -f "$SETTINGS" ]; then
+              if command -v jq >/dev/null 2>&1 && jq -e '.statusLine' "$SETTINGS" >/dev/null 2>&1; then
+                CURRENT_CMD="$(jq -r '.statusLine.command // empty' "$SETTINGS")"
+                if [ -n "$CURRENT_CMD" ] && [ -f "$CURRENT_CMD" ]; then
+                  case "$CURRENT_CMD" in
+                    *spex-ship-statusline.sh) exit 0 ;;
+                  esac
+                  echo "$CURRENT_CMD" > "$CHAIN_FILE"
+                fi
+              fi
+              TMP=$(mktemp)
+              jq --arg cmd "$ABS_SCRIPT" '.statusLine = {"type": "command", "command": $cmd}' "$SETTINGS" > "$TMP"
+              mv "$TMP" "$SETTINGS"
+            else
+              jq -n --arg cmd "$ABS_SCRIPT" '{statusLine: {type: "command", command: $cmd}}' > "$SETTINGS"
+            fi
+            echo "Status line configured" >&2
+      codex:
+        - id: codex-hooks
+          type: shell
+          run: |
+            SOURCE="{{ steps.locate-source.output.stdout }}"
+            mkdir -p .codex
+            CODEX_PRETOOL="$(cd "$SOURCE/scripts/adapters/codex" 2>/dev/null && pwd)/pretool-gate.py"
+            CODEX_CONTEXT="$(cd "$SOURCE/scripts/adapters/codex" 2>/dev/null && pwd)/context-hook.py"
+            if [ ! -f "$CODEX_PRETOOL" ] || [ ! -f "$CODEX_CONTEXT" ]; then
+              echo "WARNING: Codex adapter scripts not found" >&2
+              exit 0
+            fi
+            SPEX_HOOKS=$(jq -n --arg ctx "python3 $CODEX_CONTEXT" --arg pre "python3 $CODEX_PRETOOL" \
+              '[{type:"command",event:"UserPromptSubmit",command:$ctx},{type:"command",event:"PreToolUse",command:$pre}]')
+            if [ -f .codex/hooks.json ]; then
+              TMP=$(mktemp)
+              jq --argjson spex "$SPEX_HOOKS" '
+                .hooks = ([.hooks // [] | .[] | select(
+                  (.command | test("context-hook\\.py|pretool-gate\\.py") | not)
+                )] + $spex)
+              ' .codex/hooks.json > "$TMP"
+              mv "$TMP" .codex/hooks.json
+            else
+              jq -n --argjson hooks "$SPEX_HOOKS" '{hooks: $hooks}' > .codex/hooks.json
+            fi
+            echo "Codex adapter hooks installed" >&2
+        - id: codex-agents-md
+          type: shell
+          run: |
+            SOURCE="{{ steps.locate-source.output.stdout }}"
+            TEMPLATE="$SOURCE/templates/agents-md/codex.md"
+            if [ -f "$TEMPLATE" ]; then
+              cp "$TEMPLATE" AGENTS.md
+              echo "AGENTS.md generated for Codex" >&2
+            fi
+      opencode:
+        - id: opencode-plugin
+          type: shell
+          run: |
+            SOURCE="{{ steps.locate-source.output.stdout }}"
+            mkdir -p .opencode/plugins
+            PLUGIN="$SOURCE/scripts/adapters/opencode/spex-plugin.ts"
+            if [ -f "$PLUGIN" ]; then
+              cp "$PLUGIN" .opencode/plugins/spex-plugin.ts
+              echo "OpenCode plugin installed" >&2
+            fi
+        - id: opencode-agents-md
+          type: shell
+          run: |
+            SOURCE="{{ steps.locate-source.output.stdout }}"
+            TEMPLATE="$SOURCE/templates/agents-md/opencode.md"
+            if [ -f "$TEMPLATE" ]; then
+              cp "$TEMPLATE" AGENTS.md
+              echo "AGENTS.md generated for OpenCode" >&2
+            fi
+    default:
+      - id: default-harness
+        type: shell
+        run: |
+          echo "No agent-specific configuration applied." >&2
+          echo "Extensions installed with neutral defaults." >&2
+          echo "Use 'specify extension list' to see available extensions." >&2
+
+  - id: configure-permissions
+    type: if
+    condition: "{{ inputs.permissions }} != 'none'"
+    then:
+      - id: permissions-dispatch
+        type: switch
+        expression: "{{ steps.detect-agent.output.stdout }}"
+        cases:
+          claude:
+            - id: claude-permissions
+              type: shell
+              run: |
+                LEVEL="{{ inputs.permissions }}"
+                SETTINGS=".claude/settings.json"
+                mkdir -p .claude
+
+                if [ "$LEVEL" = "yolo" ]; then
+                  ALLOW='["Bash(*)", "Read(*)", "Edit(*)", "Write(*)", "Skill", "Agent(*)", "WebFetch", "WebSearch", "EnterPlanMode", "ExitPlanMode", "EnterWorktree", "ExitWorktree"]'
+                  MODE='"bypassPermissions"'
+                else
+                  ALLOW='["Skill", "Bash(specify *)", "Bash(*spex-init.sh*)", "Bash(*spex-ship-statusline.sh*)"]'
+                  MODE='null'
+                fi
+
+                if [ -f "$SETTINGS" ]; then
+                  TMP=$(mktemp)
+                  if [ "$MODE" = "null" ]; then
+                    jq --argjson allow "$ALLOW" '
+                      .permissions.allow = ((.permissions.allow // []) + $allow | unique)
+                    ' "$SETTINGS" > "$TMP"
+                  else
+                    jq --argjson allow "$ALLOW" --argjson mode "$MODE" '
+                      .permissions.allow = ((.permissions.allow // []) + $allow | unique) |
+                      .permissions.defaultMode = $mode
+                    ' "$SETTINGS" > "$TMP"
+                  fi
+                  mv "$TMP" "$SETTINGS"
+                else
+                  if [ "$MODE" = "null" ]; then
+                    jq -n --argjson allow "$ALLOW" '{permissions: {allow: $allow}}' > "$SETTINGS"
+                  else
+                    jq -n --argjson allow "$ALLOW" --argjson mode "$MODE" '{permissions: {defaultMode: $mode, allow: $allow}}' > "$SETTINGS"
+                  fi
+                fi
+                echo "Claude Code permissions configured ($LEVEL)" >&2
+          codex:
+            - id: codex-permissions
+              type: shell
+              run: |
+                echo "Codex permissions are managed via .codex/hooks.json (configured in adapt-harness step)" >&2
+          opencode:
+            - id: opencode-permissions
+              type: shell
+              run: |
+                echo "OpenCode permissions are managed via the spex-plugin.ts (configured in adapt-harness step)" >&2
+
+  - id: configure-gitignore
+    type: shell
+    run: |
+      GITIGNORE=".gitignore"
+      SENTINEL="# spex: generated/local files"
+      if [ -f "$GITIGNORE" ]; then
+        if grep -qF ".claude/commands/speckit." "$GITIGNORE" 2>/dev/null; then
+          sed -i.bak 's|\.claude/commands/speckit\.\*|.claude/skills/|' "$GITIGNORE" && rm -f "$GITIGNORE.bak"
+        elif grep -qF ".claude/skills/speckit-*" "$GITIGNORE" 2>/dev/null; then
+          sed -i.bak 's|\.claude/skills/speckit-\*|.claude/skills/|' "$GITIGNORE" && rm -f "$GITIGNORE.bak"
+        fi
+        if grep -qF ".specify/.spex-phase" "$GITIGNORE" 2>/dev/null; then
+          sed -i.bak '/.specify\/.spex-phase/d;/.specify\/.spex-state/d;/.claude\/skills\//d;/.claude\/settings\.local\.json/d' "$GITIGNORE" && rm -f "$GITIGNORE.bak"
+        fi
+      fi
+      [ -f "$GITIGNORE" ] && grep -qF "$SENTINEL" "$GITIGNORE" 2>/dev/null && exit 0
+      cat >> "$GITIGNORE" << 'GIEOF'
+
+      # spex: generated/local files (only constitution is committed)
+      **/.claude/
+      **/.specify/**
+      !**/.specify/memory/
+      !**/.specify/memory/constitution.md
+      GIEOF
+      echo "Updated .gitignore with spex patterns" >&2
+
+  - id: fix-constitution
+    type: shell
+    run: |
+      if [ -L ".specify/memory/constitution.md" ]; then
+        if [ -f ".specify/memory/constitution.md" ]; then
+          cat ".specify/memory/constitution.md" > ".specify/memory/constitution.md.tmp"
+          rm ".specify/memory/constitution.md"
+          mv ".specify/memory/constitution.md.tmp" ".specify/memory/constitution.md"
+        fi
+        [ -f "specs/constitution.md" ] && [ ! -L "specs/constitution.md" ] && rm "specs/constitution.md" || true
+      elif [ -f "specs/constitution.md" ] && [ ! -e ".specify/memory/constitution.md" ]; then
+        mkdir -p .specify/memory
+        mv specs/constitution.md .specify/memory/constitution.md
+      elif [ -f "specs/constitution.md" ] && [ -f ".specify/memory/constitution.md" ] && [ ! -L ".specify/memory/constitution.md" ]; then
+        rm "specs/constitution.md"
+      fi
+      printf "ok"
+
+  - id: check-update
+    type: shell
+    run: |
+      command -v curl >/dev/null 2>&1 || exit 0
+      command -v jq >/dev/null 2>&1 || exit 0
+      RESPONSE=$(curl -sf --connect-timeout 2 --max-time 3 \
+        "https://api.github.com/repos/rhuss/cc-spex/releases/latest" 2>/dev/null) || exit 0
+      LATEST_TAG=$(echo "$RESPONSE" | jq -r '.tag_name // empty' 2>/dev/null)
+      [ -n "$LATEST_TAG" ] || exit 0
+      LATEST="${LATEST_TAG#v}"
+      echo "Latest spex release: $LATEST" >&2
+      printf "%s" "$LATEST"
+
+  - id: cleanup-source
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      case "$SOURCE" in
+        "${TMPDIR:-/tmp}"/spex-setup-*/spex|/tmp/spex-setup-*/spex)
+          CLONE_DIR="${SOURCE%/spex}"
+          rm -rf "$CLONE_DIR" 2>/dev/null || true
+          ;;
+      esac
+      printf "ok"


### PR DESCRIPTION
## Why This Change

Spex's installation and setup logic lives in a 400-line bash script (`spex-init.sh`) that only works on Claude Code. Every new agent harness or extension requires more branches in this centralized script, maintained by someone who didn't write the extension. The spec-kit workflow engine already has everything needed to express this setup logic as declarative YAML with per-agent branching, making spex installable on any spec-kit-supported harness with a single command.

## What Changes

`spex-init.sh` is replaced by a spec-kit setup workflow (`setup.yml`) as the primary install mechanism. The workflow installs all spex extensions, auto-detects the agent harness (Claude Code, Codex, OpenCode), applies per-agent configuration (permissions, hooks, context files), and optionally offers interactive extension selection. Users install spex via `specify workflow run <url>` regardless of their harness. The Claude Code plugin stays as a compatibility shim that delegates to the workflow.

## How It Works

The setup workflow uses spec-kit's workflow engine with `shell`, `switch`, `if`, and `prompt` step types. It runs `specify init`, detects the agent, installs 7 extensions in dependency order, applies per-harness configuration via `switch` branches, and configures permissions. A `bundle.yml` declares distribution metadata. `spex-init.sh` gains delegation logic to call the workflow when `specify` CLI is available.

---

> [!IMPORTANT]
> **[Review Guide](https://github.com/rhuss/cc-spex/blob/037-workflow-setup/specs/037-workflow-setup/REVIEWERS.md)** contains the full review guidance: key decisions, scope boundaries, areas needing attention, and review checklist.

This PR contains the specification artifacts for **Workflow-Based Setup**. Implementation follows after spec approval.

Assisted-By: 🤖 Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rhuss/cc-spex/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workflow-based setup (`setup.yml`) for installing Spex extensions across multiple harnesses, including dependency-aware optional extension selection, per-harness permission handling, and idempotent re-runs.
  * Updated `/spex:init` to delegate to the workflow when available (with legacy fallback).
  * Added bundle metadata and workflow publishing support.
* **Documentation**
  * Updated installation/initialization guides and help text.
  * Published workflow spec materials (plan, spec, data model, research, tasks, reviewer checklist, and requirements checklist) plus updated review findings.
* **Chores**
  * Updated configuration to point to the new workflow-setup spec directory.
  * Enhanced release publishing to bump/add version strings in additional workflow/bundle manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->