### PR TITLE
feat: add workflow-first Spex setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  generated-tree-discipline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject tracked generated harness trees
+        run: make test-generated-trees

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Reject tracked generated harness trees
         run: make test-generated-trees

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,10 @@ build/
 
 # spex: generated/local files (only constitution is committed)
 **/.claude/
+**/.agents/
+**/.codex/
 **/.specify/**
+!**/.specify/spex.json
 !**/.specify/memory/
 !**/.specify/memory/constitution.md
 .playwright-mcp/

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/045-detach-stealth-mode"
+  "feature_directory": "specs/048-workflow-first-setup"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate install uninstall reinstall check-upstream test-hook test-install test-install-remote release migrate sync-scripts sync-scripts-check help
+.PHONY: validate install uninstall reinstall check-upstream test-hook test-install test-install-remote test-setup-profile test-workflow-setup test-generated-trees release migrate sync-scripts sync-scripts-check help
 
 MARKETPLACE := spex-plugin-development
 PLUGIN := spex@$(MARKETPLACE)
@@ -10,6 +10,15 @@ OLD_PLUGIN := sdd@$(OLD_MARKETPLACE)
 validate:
 	claude plugin validate ./
 	claude plugin validate ./spex/
+
+test-setup-profile:
+	python3 -m unittest tests/test_setup_profile.py
+
+test-workflow-setup:
+	@tests/test_workflow_setup.sh
+
+test-generated-trees:
+	@tests/test_generated_trees.sh
 
 migrate:
 	@# Remove old sdd plugin and marketplace from pre-3.0.0 installations

--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ Autonomous and YOLO request progressively broader project-local autonomy. The
 active harness adapter remains responsible for applying or safely degrading that
 request.
 
+The former `permissions` workflow input remains available as a deprecated alias:
+`none` maps to `safe`, `standard` maps to `autonomous`, and `yolo` remains
+`yolo`. When both inputs are supplied, `security` takes precedence.
+
 Claude plugin development remains source-transparent: `make install` installs
 directly from the checkout without a materialization step.
 

--- a/README.md
+++ b/README.md
@@ -204,11 +204,33 @@ specify workflow run https://github.com/rhuss/cc-spex/releases/latest/download/s
 
 # Customize with inputs
 specify workflow run spex/setup.yml -i "extensions=spex-gates,spex-worktrees"
-specify workflow run spex/setup.yml -i "permissions=yolo"
+specify workflow run spex/setup.yml -i "security=autonomous"
 specify workflow run spex/setup.yml -i "integration=codex"
 ```
 
 The workflow auto-detects the agent harness, installs extensions, and applies per-agent configuration (including command adaptation, see below). Prerequisites: `specify` CLI (>= 0.7.4), `git`, and `jq`. The existing Claude Code plugin will delegate to this workflow when available, falling back to direct init otherwise.
+
+The first successful setup records requested project intent in
+`.specify/spex.json`. Commit this file so teammates and later refreshes use the
+same harness preference, extension selection, and requested security:
+
+```json
+{
+  "schema_version": 1,
+  "harness": "auto",
+  "extensions": ["spex", "spex-gates", "spex-worktrees", "spex-deep-review"],
+  "security": "safe"
+}
+```
+
+Explicit workflow inputs override stored values and update the declaration only
+after validation. Without explicit inputs, setup reuses it. Safe is recommended;
+Autonomous and YOLO request progressively broader project-local autonomy. The
+active harness adapter remains responsible for applying or safely degrading that
+request.
+
+Claude plugin development remains source-transparent: `make install` installs
+directly from the checkout without a materialization step.
 
 ### Neutral Command Vocabulary
 

--- a/specs/048-workflow-first-setup/REVIEWERS.md
+++ b/specs/048-workflow-first-setup/REVIEWERS.md
@@ -1,0 +1,36 @@
+# Review Guide: Workflow-First Spex Setup
+
+## Purpose
+
+This PR replaces only the setup/configuration slice of the abandoned monolithic Codex-support delivery. It does not introduce the Codex adapter, plugin packaging, workflow-state recovery, progress, Teams, or production OpenCode work.
+
+## Focused cross-harness review
+
+Please verify:
+
+1. The Spec-Kit workflow remains the primary installation and refresh path.
+2. `.specify/spex.json` contains requested team-owned intent only; it does not accumulate detected capabilities, effective policy, timestamps, or workflow state.
+3. Configuration behavior is implemented by one focused utility rather than a generic adapter or materialization framework.
+4. Generated `.agents/`, `.codex/`, and `.claude/skills/` trees cannot become maintained duplicate sources.
+5. Existing explicit repository configuration such as `.claude/settings.json` remains permitted.
+6. Claude installation and debugging continue directly from canonical repository sources without staging.
+7. No deferred feature-047 subsystem was imported to make this PR work.
+
+## Evidence
+
+- `make test-setup-profile`
+- `make test-workflow-setup`
+- `make test-generated-trees`
+- `make validate`
+- `make sync-scripts-check`
+- `make test-install` — 39 assertions
+- JSON Schema metaschema and valid-fixture checks
+
+## Deferred deliberately
+
+- Native Codex hooks and project policy translation
+- Thin Codex marketplace discovery plugin
+- Worktree/state authority
+- Ship recovery and progress
+- Teams/subagent execution
+- Production OpenCode support

--- a/specs/048-workflow-first-setup/checklists/requirements.md
+++ b/specs/048-workflow-first-setup/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Workflow-First Spex Setup
+
+**Purpose**: Validate specification completeness and quality before planning  
+**Created**: 2026-07-25  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The monolithic feature 047 branch remains an implementation reference. This feature deliberately excludes Codex adapters, native plugin packaging, workflow-state recovery, progress, and Teams.

--- a/specs/048-workflow-first-setup/contracts/spex-project-config.schema.json
+++ b/specs/048-workflow-first-setup/contracts/spex-project-config.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cc-spex.dev/contracts/spex-project-config.schema.json",
+  "title": "Spex Project Configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "harness", "extensions", "security"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "harness": { "enum": ["auto", "claude", "codex", "opencode"] },
+    "extensions": {
+      "type": "array",
+      "uniqueItems": true,
+      "contains": { "const": "spex" },
+      "items": {
+        "enum": ["spex", "spex-gates", "spex-worktrees", "spex-deep-review", "spex-teams", "spex-collab", "spex-detach"]
+      }
+    },
+    "security": { "enum": ["safe", "autonomous", "yolo"] }
+  }
+}

--- a/specs/048-workflow-first-setup/data-model.md
+++ b/specs/048-workflow-first-setup/data-model.md
@@ -1,0 +1,44 @@
+# Data Model: Workflow-First Spex Setup
+
+## Spex Project Configuration
+
+Team-owned requested intent stored in `.specify/spex.json`.
+
+| Field | Type | Rules |
+|-------|------|-------|
+| `schema_version` | integer | Required; initially `1` |
+| `harness` | string | Required; `auto`, `claude`, `codex`, or legacy-compatible `opencode` |
+| `extensions` | array of strings | Required, unique, contains `spex`, known bundled extensions only |
+| `security` | string | Required; `safe`, `autonomous`, or `yolo` |
+
+The declaration excludes detected capabilities, generated paths, effective security, timestamps, workflow state, and revision counters so it changes only when user intent changes.
+
+## Setup Request
+
+Transient candidate produced by applying precedence independently to every field:
+
+```text
+explicit input > stored project configuration > recommended default
+```
+
+The complete request is validated before persistence or extension mutation.
+
+## Setup Resolution
+
+Validated normalized request consumed by workflow steps. Extension dependency closure is applied before persistence, so the declaration records the actual requested installation.
+
+## State transitions
+
+```text
+absent configuration
+        ↓ resolve defaults or interactive selections
+candidate request
+        ↓ validate fields and dependency closure
+validated resolution
+        ↓ atomic replacement after accepted selection
+persisted project configuration
+        ↓ later explicit override
+new validated resolution → atomic replacement
+```
+
+Validation failure leaves the previous persisted configuration byte-identical.

--- a/specs/048-workflow-first-setup/plan.md
+++ b/specs/048-workflow-first-setup/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: Workflow-First Spex Setup
+
+**Branch**: `048-workflow-first-setup` | **Date**: 2026-07-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/048-workflow-first-setup/spec.md`
+
+## Summary
+
+Make the existing Spec-Kit setup workflow the authoritative installation path by adding a small, project-owned `.specify/spex.json` declaration. A Python standard-library profile utility validates, resolves, and atomically persists requested intent; workflow prompts collect first-run choices and feed the same resolver used by non-interactive refresh. Repository ignore rules and a focused CI check keep generated `.agents/`, `.codex/`, and `.claude/` trees disposable while explicitly allowing the team-owned declaration. Claude's existing source install remains unchanged and requires no staged distribution.
+
+## Technical Context
+
+**Language/Version**: Python 3.9+ standard library, POSIX shell, Spec-Kit workflow YAML  
+**Primary Dependencies**: `specify` CLI, `git`, `jq`; no new parser dependency  
+**Storage**: Project-owned JSON declaration plus existing generated project files  
+**Testing**: Python unit tests and shell integration tests in temporary Git repositories  
+**Target Platform**: macOS and Linux environments supported by Spec-Kit  
+**Project Type**: CLI workflow and extension bundle  
+**Performance Goals**: Configuration validation and persistence complete in under one second; repeat setup introduces no extra prompts  
+**Constraints**: Preserve current Claude installation; do not port Codex adapter, plugin packaging, state/recovery, progress, Teams, or OpenCode production support  
+**Scale/Scope**: One declaration schema, one profile utility, one setup workflow integration, one generated-tree guard
+
+## Constitution Check
+
+*GATE: Passed before research and re-checked after design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-Guided Development | PASS | New scoped feature package replaces the monolithic delivery plan. |
+| II. Extension Architecture | PASS | Setup continues installing native Spec-Kit extensions. |
+| III. Extension Composability | PASS | Selection and dependency closure remain centralized in setup. |
+| IV. Quality Gates | PASS | Unit and end-to-end setup tests are required before completion. |
+| V. Naming Discipline | PASS | Existing `specify` and `speckit-*` conventions are retained. |
+| VI. Skill Autonomy | PASS | Configuration logic lives in a script rather than an oversized init skill. |
+| VII. State as Scripts | PASS | Validation and persistence are implemented by a dedicated utility. |
+| No compiled artifacts | PASS | Python standard library and existing shell dependencies only. |
+| Source-transparent Claude development | PASS | The existing source plugin path remains the development path. |
+
+Post-design re-check: PASS. The design introduces one data declaration and one focused utility; it does not introduce a generic adapter, materializer, or new package dependency.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/048-workflow-first-setup/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── spex-project-config.schema.json
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+spex/
+├── setup.yml                         # Resolve prompts/config and persist accepted intent
+└── scripts/
+    └── spex-setup-profile.py         # Validate, resolve, and atomically persist configuration
+
+tests/
+├── test_setup_profile.py             # Profile contract and failure-atomicity tests
+├── test_workflow_setup.sh            # Disposable-repository setup journey
+└── test_generated_trees.sh           # Ignore and tracked-output guard
+
+.github/workflows/test.yml            # Run generated-tree guard
+.gitignore                            # Ignore generated harness trees; allow spex.json
+Makefile                              # Focused test targets
+README.md                             # Workflow-first setup and configuration reference
+```
+
+**Structure Decision**: Extend the existing workflow and script layout. Configuration behavior is not placed in a skill, plugin manifest, generic adapter descriptor, or new build system.
+
+## Implementation Approach
+
+1. Add contract-first tests for configuration validation, precedence, dependency closure, migration, and atomic persistence.
+2. Implement a focused profile utility with `resolve` and `persist` operations. `resolve` is read-only and emits normalized JSON; `persist` validates again and atomically replaces the declaration.
+3. Change workflow input defaults to empty sentinels so stored intent can win when no override is supplied. Preserve the existing interactive extension prompt and add equivalent security selection, then persist once after all selections normalize.
+4. Update setup ignore generation to ignore `.agents/`, `.codex/`, and `.claude/` while explicitly allowing `.specify/spex.json`.
+5. Add a tracked-generated-tree guard with a narrow maintained-source allowlist and run it in CI.
+6. Document the primary workflow command, declaration format, precedence, defaults, and source-transparent Claude development path.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/048-workflow-first-setup/quickstart.md
+++ b/specs/048-workflow-first-setup/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: Validate Workflow-First Setup
+
+## Prerequisites
+
+- `specify` CLI supported by the repository
+- `git`, `jq`, and Python 3.9 or newer
+
+## 1. Validate profile behavior
+
+```bash
+python3 -m unittest tests/test_setup_profile.py
+```
+
+Expected: defaults, stored values, explicit overrides, dependency closure, invalid inputs, migration, and atomic replacement pass.
+
+## 2. Validate first setup
+
+In a disposable Git repository, run the local setup workflow with explicit non-default selections:
+
+```bash
+specify workflow run spex/setup.yml \
+  -i integration=claude \
+  -i extensions=spex-gates,spex-worktrees \
+  -i security=autonomous
+```
+
+Expected: `.specify/spex.json` records the accepted request and the installed extension set matches it.
+
+## 3. Validate refresh
+
+Run the workflow again without selection inputs.
+
+Expected: no selection prompt, stored intent is reused, and `.specify/spex.json` is byte-identical.
+
+## 4. Validate generated-tree discipline
+
+```bash
+make test-generated-trees
+```
+
+Expected: generated harness paths are ignored, `.specify/spex.json` is visible to Git, and a force-tracked generated skill fixture is rejected.
+
+## 5. Validate Claude source transparency
+
+Run the existing local Claude marketplace installation test without invoking a materialization target.
+
+Expected: installation and setup pass directly from repository sources.

--- a/specs/048-workflow-first-setup/research.md
+++ b/specs/048-workflow-first-setup/research.md
@@ -1,0 +1,49 @@
+# Research: Workflow-First Spex Setup
+
+## Project configuration format
+
+**Decision**: Store requested project intent in `.specify/spex.json`.
+
+**Rationale**: `jq` is already a setup dependency, JSON has an unambiguous standard parser, and Python 3.9 can read and write it without additional modules. This avoids adding `yq`, PyYAML, or a partial YAML implementation.
+
+**Alternatives considered**: YAML requires another parser; TOML is not readable through Python's standard library on macOS Python 3.9; `.specify/init-options.json` is owned by Spec-Kit.
+
+## Ownership and persistence
+
+**Decision**: Treat `.specify/spex.json` as user/team-owned intent and keep generated/effective state outside it. Persist only after the whole request validates, using same-directory temporary-file replacement.
+
+**Rationale**: A declaration must remain stable across harness refreshes and must not falsely claim that a requested security level was applied. Atomic replacement prevents partial configuration after interruption.
+
+**Alternatives considered**: Mixing requested and effective values causes unrelated churn; incremental writes can leave misleading partial intent.
+
+## Input precedence
+
+**Decision**: Resolve values in this order: explicit workflow input, stored project intent, recommended default. Empty workflow inputs mean “not explicitly supplied.”
+
+**Rationale**: Concrete workflow defaults otherwise overwrite stored non-default choices on every refresh.
+
+**Alternatives considered**: Environment variables are invisible and session-scoped; fixed workflow defaults cannot distinguish omission from override.
+
+## Interactive setup
+
+**Decision**: Keep interaction in workflow prompt steps. Normalize their result through the same profile utility used by scripted setup, then persist once.
+
+**Rationale**: Profile code remains independent of agent UI and plugin installation.
+
+**Alternatives considered**: A plugin init skill would make the plugin mandatory; an interactive Python utility would duplicate harness UI behavior.
+
+## Generated-tree discipline
+
+**Decision**: Ignore `.agents/`, `.codex/`, and project-local `.claude/` trees, explicitly unignore `.specify/spex.json`, and add a tracked-file guard with a narrow allowlist for maintained repository sources.
+
+**Rationale**: Ignore rules prevent ordinary accidents; a tracked-file check catches force-added or previously tracked generated files.
+
+**Alternatives considered**: Ignore rules alone are bypassable; rejecting all agent-named paths would reject legitimate maintained descriptors and `AGENTS.md`.
+
+## Native plugin lifecycle
+
+**Decision**: Defer native plugin discovery to a separate feature. A future thin plugin may expose an explicit init skill, but installation will not execute the Specify workflow implicitly.
+
+**Rationale**: The current Codex contract has no supported post-install command lifecycle. Silent setup would also expand installation authority unexpectedly.
+
+**Alternatives considered**: Unsupported install hooks and retaining the complete feature-047 materializer were rejected.

--- a/specs/048-workflow-first-setup/research.md
+++ b/specs/048-workflow-first-setup/research.md
@@ -6,6 +6,10 @@
 
 **Rationale**: `jq` is already a setup dependency, JSON has an unambiguous standard parser, and Python 3.9 can read and write it without additional modules. This avoids adding `yq`, PyYAML, or a partial YAML implementation.
 
+**Plan deviation**: Early discussion used `.specify/spex.yml` as an illustrative
+name. The implementation deliberately standardizes on JSON for the portability
+reason above; this is a conscious contract choice rather than an oversight.
+
 **Alternatives considered**: YAML requires another parser; TOML is not readable through Python's standard library on macOS Python 3.9; `.specify/init-options.json` is owned by Spec-Kit.
 
 ## Ownership and persistence

--- a/specs/048-workflow-first-setup/spec.md
+++ b/specs/048-workflow-first-setup/spec.md
@@ -72,6 +72,9 @@ A Claude plugin maintainer can install and debug the plugin directly from the so
 ### Edge Cases
 
 - Existing repositories may contain legacy setup inputs but no durable Spex project configuration.
+- Existing automation may still pass the deprecated `permissions` input. Setup
+  must map `none`, `standard`, and `yolo` to the new security vocabulary, with
+  an explicit `security` input taking precedence.
 - A configuration may name an unknown extension, omit the mandatory core extension, or contain an unsupported security value.
 - Setup may be interrupted after extensions change but before harness configuration is generated.
 - A repository may intentionally track a root `AGENTS.md` while ignoring generated `.agents/` contents.

--- a/specs/048-workflow-first-setup/spec.md
+++ b/specs/048-workflow-first-setup/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Workflow-First Spex Setup
+
+**Feature Branch**: `048-workflow-first-setup`  
+**Created**: 2026-07-25  
+**Status**: Draft  
+**Input**: Replace the monolithic Codex-support delivery with a workflow-first setup that persists user intent, remains source-transparent for Claude development, and treats generated harness trees as disposable outputs.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Repeat Setup from Project Configuration (Priority: P1)
+
+A developer records the desired Spex harness, extensions, and security level in project configuration. Any teammate can rerun the Spex setup workflow and receive the same selections without answering the setup questionnaire again.
+
+**Why this priority**: A durable, reviewable declaration makes the Spec-Kit workflow sufficient as the primary installation and refresh mechanism.
+
+**Independent Test**: Add a valid Spex project configuration to a clean repository, run setup without selection overrides, and verify that the declared extensions and security intent are applied and preserved on a second run.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository containing valid Spex project configuration, **When** setup runs without explicit overrides, **Then** it uses the recorded harness preference, extension selection, and security level.
+2. **Given** a configured repository, **When** setup runs repeatedly, **Then** the resulting enabled extensions and requested security remain unchanged and no duplicate configuration is introduced.
+3. **Given** explicit setup inputs and existing project configuration, **When** setup runs, **Then** the explicit inputs take precedence and the accepted result becomes the new recorded intent.
+4. **Given** setup creates or updates project configuration, **When** a teammate inspects the repository, **Then** that declaration is visible to version control and can be reviewed and shared.
+
+---
+
+### User Story 2 - Bootstrap Configuration Interactively (Priority: P1)
+
+A developer without Spex project configuration runs the setup workflow, chooses from clearly described harness, extension, and security options, and receives both a working installation and a durable configuration for future refreshes.
+
+**Why this priority**: First-time setup must remain approachable while converging onto the same repeatable path used by automated and team-owned setup.
+
+**Independent Test**: Run setup in an unconfigured disposable repository, choose non-default options, and verify that the resulting project configuration reproduces those choices on a non-interactive refresh.
+
+**Acceptance Scenarios**:
+
+1. **Given** no Spex project configuration, **When** interactive setup begins, **Then** it identifies the recommended defaults and describes every additional extension and security choice.
+2. **Given** the user accepts or changes the proposed selections, **When** setup completes, **Then** the accepted intent is stored in project configuration before harness-specific settings are generated.
+3. **Given** setup cannot apply the requested configuration, **When** it fails, **Then** it reports the failing selection and does not persist a partially accepted configuration.
+
+---
+
+### User Story 3 - Preserve Canonical Source Ownership (Priority: P1)
+
+A Spex contributor edits canonical workflow and extension sources without maintaining generated copies under agent-specific project directories. Repository safeguards detect generated harness trees before they are committed.
+
+**Why this priority**: The workflow-first architecture depends on a single maintained source; accidental generated-tree commits would recreate the duplication it is designed to prevent.
+
+**Independent Test**: Generate Claude and Codex project files in the repository, verify Git ignores them, then stage representative generated paths forcibly and verify the repository quality check rejects them.
+
+**Acceptance Scenarios**:
+
+1. **Given** setup generates project-local Claude, Codex, or shared agent files, **When** Git status is inspected, **Then** generated skill and harness configuration trees are ignored.
+2. **Given** a generated harness file is forcibly added, **When** repository quality checks run, **Then** they fail with guidance to edit canonical Spex sources instead.
+3. **Given** a deliberately maintained plugin descriptor or repository guidance file, **When** generated-tree safeguards run, **Then** the maintained source remains allowed.
+
+---
+
+### User Story 4 - Develop Claude Directly from Source (Priority: P2)
+
+A Claude plugin maintainer can install and debug the plugin directly from the source tree without first producing a staged cross-harness distribution.
+
+**Why this priority**: Claude's native plugin model is source-transparent, and ordinary development should not acquire a build boundary solely because another harness may require packaging.
+
+**Independent Test**: Install the Claude plugin from a clean source checkout, invoke its setup entry point, and verify that no materialization command or staged distribution is required.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean Spex source checkout, **When** a maintainer performs the documented Claude development install, **Then** the plugin runs directly from canonical sources.
+2. **Given** optional release packaging is unavailable, **When** Claude development tests run, **Then** source installation and workflow setup remain functional.
+
+### Edge Cases
+
+- Existing repositories may contain legacy setup inputs but no durable Spex project configuration.
+- A configuration may name an unknown extension, omit the mandatory core extension, or contain an unsupported security value.
+- Setup may be interrupted after extensions change but before harness configuration is generated.
+- A repository may intentionally track a root `AGENTS.md` while ignoring generated `.agents/` contents.
+- Existing ignore rules may contain narrower Claude patterns that need migration without discarding user entries.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Spex MUST provide one project-owned declaration of requested harness preference, enabled extensions, and security level.
+- **FR-002**: Project configuration MUST distinguish user-requested intent from generated harness configuration and transient workflow state.
+- **FR-003**: Setup MUST use project configuration when explicit invocation inputs are absent.
+- **FR-004**: Explicit invocation inputs MUST override stored values for that run and MUST update stored intent only after the complete selection is validated.
+- **FR-005**: First-time setup MUST present the recommended extension set by default and expose all optional extensions with concise descriptions.
+- **FR-006**: First-time setup MUST expose exactly three security choices: Safe, Autonomous, and YOLO, with Safe recommended by default.
+- **FR-007**: The project declaration MUST record requested security intent only; detected capabilities and effective harness policy MUST remain owned by the corresponding harness adapter.
+- **FR-008**: Setup MUST describe Safe as preserving host policy, Autonomous as reducing prompts for enumerated project operations, and YOLO as requesting the broadest project-local autonomy the active harness can safely express.
+- **FR-009**: Setup MUST NOT claim that requested security is effective until the active harness adapter has applied or safely degraded it.
+- **FR-010**: Harness-specific fallback confirmation and effective-policy persistence MUST be delivered and tested with the corresponding harness adapter rather than encoded in the shared declaration.
+- **FR-011**: Setup MUST validate the complete requested configuration before changing the persisted declaration.
+- **FR-012**: Setup MUST reject unknown harnesses, extensions, and security values with actionable diagnostics.
+- **FR-013**: Setup MUST remain idempotent and preserve valid selections during refresh.
+- **FR-014**: The project-owned Spex declaration MUST be visible to version control and MUST NOT be treated as transient workflow state.
+- **FR-015**: Generated `.agents/`, `.codex/`, and project-local `.claude/` trees MUST be excluded from ordinary version control discovery.
+- **FR-016**: Repository quality checks MUST reject tracked generated harness artifacts while allowing explicitly maintained distribution descriptors and repository guidance.
+- **FR-017**: Canonical workflow, extension, and setup behavior MUST remain owned under the maintained Spex source tree.
+- **FR-018**: Claude source development and installation MUST NOT require plugin materialization or a staged distribution.
+- **FR-019**: Existing repositories without the new declaration MUST receive deterministic migration behavior that preserves any discoverable valid selections and otherwise uses documented defaults.
+- **FR-020**: Setup failure MUST identify whether requested intent was persisted and MUST NOT leave a partially written project declaration.
+
+### Key Entities
+
+- **Spex Project Configuration**: Team-owned requested setup intent, including harness preference, extension selection, security level, and configuration format version.
+- **Generated Harness Tree**: Disposable project-local skills, hooks, and settings produced for a specific coding agent.
+- **Setup Resolution**: The validated effective selection obtained from defaults, stored intent, and explicit invocation inputs in precedence order.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A configured repository can be refreshed twice with zero additional selection prompts and byte-identical requested configuration.
+- **SC-002**: The project-owned configuration appears as an ordinary reviewable repository file while generated harness trees remain absent from ordinary Git status.
+- **SC-003**: Clean-repository tests cover default setup, non-default setup, explicit override, invalid configuration, migration, and interrupted persistence without manual file repair.
+- **SC-004**: Generated Claude and Codex project trees produce no ordinary Git status entries in every supported setup test.
+- **SC-005**: A forced attempt to track a representative generated skill fails the repository quality gate in every tested harness.
+- **SC-006**: Claude source installation and its setup smoke test pass without invoking a materialization command.
+- **SC-007**: The setup documentation presents one primary workflow-based path and allows a new user to identify defaults and alternatives without consulting plugin internals.
+
+## Assumptions
+
+- The core `spex` extension remains mandatory; init-only operation is separate follow-up work.
+- Native Codex hooks, security-policy translation, linked-worktree behavior, and skill presentation belong to the next scoped feature.
+- Native plugin marketplace discovery is a separate packaging feature and is not required for successful workflow setup.
+- Worktree state transfer, ship recovery, progress presentation, and Teams behavior remain outside this feature.
+- OpenCode is not a supported acceptance target for this feature.

--- a/specs/048-workflow-first-setup/tasks.md
+++ b/specs/048-workflow-first-setup/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Workflow-First Spex Setup
+
+**Input**: Design documents from `/specs/048-workflow-first-setup/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Contract and integration tests are required by SC-002 through SC-005 and are written before implementation.
+
+## Phase 1: Setup
+
+**Purpose**: Establish the configuration contract and focused test entry points.
+
+- [x] T001 Add valid and invalid Spex project configuration fixtures under `tests/fixtures/setup-profile/`
+- [x] T002 [P] Add `test-setup-profile` and `test-generated-trees` targets to `Makefile`
+- [x] T003 [P] Add the project configuration schema validation case to `tests/test_setup_profile.py`
+
+---
+
+## Phase 2: Foundational Profile Contract
+
+**Purpose**: Define the read-only resolution and failure-atomic persistence behavior used by all setup stories.
+
+- [x] T004 Add failing tests for defaults, stored intent, explicit precedence, normalization, dependency closure, requested-security vocabulary, and invalid values in `tests/test_setup_profile.py`
+- [x] T005 Add failing tests for atomic persistence, byte-identical failure behavior, and legacy-input migration in `tests/test_setup_profile.py`
+- [x] T006 Implement validation, resolution, dependency closure, and JSON output in `spex/scripts/spex-setup-profile.py`
+- [x] T007 Implement same-directory atomic persistence and migration in `spex/scripts/spex-setup-profile.py`
+
+**Checkpoint**: The profile utility independently satisfies the configuration contract without invoking a workflow or harness adapter.
+
+---
+
+## Phase 3: User Story 1 - Repeat Setup from Project Configuration (Priority: P1) 🎯 MVP
+
+**Goal**: A committed project declaration drives repeatable, non-interactive refresh.
+
+**Independent Test**: Run setup twice in a disposable repository and verify the second run reuses a byte-identical declaration without selection prompts.
+
+- [x] T008 [US1] Add a failing configured-refresh journey to `tests/test_workflow_setup.sh`
+- [x] T009 [US1] Resolve empty workflow inputs from `.specify/spex.json` before harness detection and extension selection in `spex/setup.yml`
+- [x] T010 [US1] Persist the validated normalized request once after selection and before harness-specific generation in `spex/setup.yml`
+
+**Checkpoint**: Stored non-default intent survives a prompt-free refresh.
+
+---
+
+## Phase 4: User Story 2 - Bootstrap Configuration Interactively (Priority: P1)
+
+**Goal**: First setup presents all choices and converges onto the same durable declaration.
+
+**Independent Test**: Supply simulated prompt responses in a clean repository and verify a subsequent non-interactive refresh reproduces them.
+
+- [x] T011 [US2] Add failing first-run default, non-default, and rejected-selection journeys to `tests/test_workflow_setup.sh`
+- [x] T012 [US2] Update extension selection to expose recommended and optional choices and emit a normalized selection from `spex/setup.yml`
+- [x] T013 [US2] Add requested Safe, Autonomous, and YOLO selection with Safe recommended in `spex/setup.yml`
+- [x] T014 [US2] Ensure failed validation leaves `.specify/spex.json` absent or byte-identical in `spex/setup.yml`
+
+**Checkpoint**: Interactive and scripted setup produce the same declaration and refresh behavior.
+
+---
+
+## Phase 5: User Story 3 - Preserve Canonical Source Ownership (Priority: P1)
+
+**Goal**: Generated harness trees remain disposable and cannot silently become maintained copies.
+
+**Independent Test**: Verify ignore behavior in a temporary repository and verify a force-tracked generated skill fails the guard.
+
+- [x] T015 [US3] Add failing ignore and force-tracked generated-tree cases to `tests/test_generated_trees.sh`
+- [x] T016 [US3] Extend repository and generated setup ignore rules for `.agents/`, `.codex/`, `.claude/`, and the `.specify/spex.json` exception in `.gitignore` and `spex/setup.yml`
+- [x] T017 [US3] Implement the maintained-source allowlist and tracked-generated-tree rejection in `tests/test_generated_trees.sh`
+- [x] T018 [US3] Run the generated-tree guard in `.github/workflows/test.yml`
+
+**Checkpoint**: Generated trees are ignored by default, force-tracked copies fail CI, and maintained descriptors remain allowed.
+
+---
+
+## Phase 6: User Story 4 - Develop Claude Directly from Source (Priority: P2)
+
+**Goal**: Claude development stays source-transparent and independent of optional packaging.
+
+**Independent Test**: The existing local Claude install journey passes without invoking any materialization target.
+
+- [x] T019 [US4] Add an assertion to `tests/test_workflow_setup.sh` that the Claude setup journey uses canonical source paths and creates no staged distribution
+- [x] T020 [US4] Document the direct Claude development path and workflow-first user path in `README.md`
+
+**Checkpoint**: Claude source installation remains the documented and tested development workflow.
+
+---
+
+## Phase 7: Polish and Verification
+
+- [x] T021 [P] Document `.specify/spex.json`, precedence, defaults, and migration in `README.md`
+- [x] T022 [P] Validate `specs/048-workflow-first-setup/contracts/spex-project-config.schema.json` against its metaschema
+- [x] T023 Run `make test-setup-profile`, `make test-generated-trees`, the workflow setup journey, and the existing Claude marketplace installation test
+- [x] T024 Run `git diff --check` and verify the PR contains no Codex hook, plugin packaging, state/recovery, progress, Teams, or OpenCode production changes
+
+---
+
+## Dependencies and Execution Order
+
+- Phase 1 precedes the profile contract.
+- Phase 2 blocks both setup user stories.
+- User Story 1 is the minimum viable increment and precedes the interactive bootstrap integration.
+- User Story 3 is independent after Phase 1 and may be implemented alongside User Stories 1 and 2.
+- User Story 4 depends only on the final setup path and can be validated after User Story 1.
+- Polish and verification follow all selected stories.
+
+## Parallel Opportunities
+
+- T002 and T003 touch independent build and test files.
+- T015–T018 can proceed independently from workflow integration after test targets exist.
+- T020–T022 are independent documentation and contract checks after behavior stabilizes.
+
+## Implementation Strategy
+
+Deliver the profile utility and non-interactive configured refresh first. Add interactive convergence second, generated-tree enforcement in parallel, and finish with source-transparency validation. Do not import unrelated feature-047 subsystems to satisfy this feature.

--- a/spex/scripts/spex-setup-profile.py
+++ b/spex/scripts/spex-setup-profile.py
@@ -35,14 +35,20 @@ FIELDS = set(DEFAULT)
 
 
 class ProfileError(Exception):
+    """Report invalid or inaccessible setup profile data."""
+
     pass
 
 
 def fail(message: str) -> None:
+    """Raise a setup-profile validation error."""
+
     raise ProfileError(message)
 
 
 def root_path(raw: str) -> Path:
+    """Return a validated absolute project root."""
+
     root = Path(raw)
     if not root.is_absolute() or not root.is_dir():
         fail("--root must be an existing absolute directory")
@@ -50,6 +56,8 @@ def root_path(raw: str) -> Path:
 
 
 def normalize_extensions(value: Any) -> list[str]:
+    """Validate extensions, add dependencies, and return canonical order."""
+
     if not isinstance(value, list) or not value:
         fail("extensions must be a nonempty array")
     if any(not isinstance(item, str) or item not in EXTENSIONS for item in value):
@@ -60,13 +68,13 @@ def normalize_extensions(value: Any) -> list[str]:
     for extension, required in DEPENDENCIES.items():
         if extension in enabled:
             enabled.update(required)
-    order = list(DEFAULT["extensions"]) + [
-        "spex-teams", "spex-collab", "spex-detach"
-    ]
+    order = [*DEFAULT["extensions"], "spex-teams", "spex-collab", "spex-detach"]
     return [extension for extension in order if extension in enabled]
 
 
 def validate(value: Any) -> dict[str, Any]:
+    """Validate and canonicalize a complete setup declaration."""
+
     if not isinstance(value, dict):
         fail("configuration must be a JSON object")
     missing = FIELDS - set(value)
@@ -90,6 +98,8 @@ def validate(value: Any) -> dict[str, Any]:
 
 
 def read_json(stream) -> dict[str, Any]:
+    """Read a JSON object from a text stream with a stable error message."""
+
     try:
         return json.load(stream)
     except json.JSONDecodeError as error:
@@ -97,6 +107,8 @@ def read_json(stream) -> dict[str, Any]:
 
 
 def load(root: Path) -> dict[str, Any] | None:
+    """Load a stored declaration, or return None when it is absent."""
+
     path = root / PROFILE
     if not path.exists():
         return None
@@ -108,15 +120,21 @@ def load(root: Path) -> dict[str, Any] | None:
 
 
 def emit(value: dict[str, Any]) -> None:
+    """Write a canonical declaration to standard output."""
+
     json.dump(value, sys.stdout, indent=2)
     sys.stdout.write("\n")
 
 
 def parse_extension_argument(raw: str) -> list[str]:
+    """Parse a comma-separated workflow extension input."""
+
     return [item.strip() for item in raw.split(",") if item.strip()]
 
 
 def resolve(args: argparse.Namespace) -> None:
+    """Resolve explicit inputs over stored values and defaults."""
+
     root = root_path(args.root)
     stored = load(root) or DEFAULT
     security = args.security
@@ -135,6 +153,8 @@ def resolve(args: argparse.Namespace) -> None:
 
 
 def persist(args: argparse.Namespace) -> None:
+    """Atomically persist a validated declaration below the project root."""
+
     root = root_path(args.root)
     value = validate(read_json(sys.stdin))
     destination = root / PROFILE
@@ -157,11 +177,15 @@ def persist(args: argparse.Namespace) -> None:
 
 
 def validate_command(args: argparse.Namespace) -> None:
+    """Validate a declaration received on standard input."""
+
     root_path(args.root)
     emit(validate(read_json(sys.stdin)))
 
 
 def parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+
     result = argparse.ArgumentParser(description=__doc__)
     commands = result.add_subparsers(required=True)
     resolve_parser = commands.add_parser("resolve")
@@ -183,6 +207,8 @@ def parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    """Run the requested setup-profile operation."""
+
     args = parser().parse_args()
     args.handler(args)
     return 0
@@ -193,4 +219,4 @@ if __name__ == "__main__":
         raise SystemExit(main())
     except ProfileError as error:
         print(f"ERROR: {error}", file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from error

--- a/spex/scripts/spex-setup-profile.py
+++ b/spex/scripts/spex-setup-profile.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Resolve and atomically persist the team-owned Spex setup declaration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any
+
+
+PROFILE = Path(".specify/spex.json")
+HARNESSES = {"auto", "claude", "codex", "opencode"}
+EXTENSIONS = {
+    "spex", "spex-gates", "spex-worktrees", "spex-deep-review",
+    "spex-teams", "spex-collab", "spex-detach",
+}
+DEPENDENCIES = {
+    "spex-deep-review": {"spex-gates"},
+    "spex-teams": {"spex-gates"},
+    "spex-collab": {"spex-gates"},
+}
+SECURITY = {"safe", "autonomous", "yolo"}
+DEFAULT = {
+    "schema_version": 1,
+    "harness": "auto",
+    "extensions": ["spex", "spex-gates", "spex-worktrees", "spex-deep-review"],
+    "security": "safe",
+}
+LEGACY_SECURITY = {"none": "safe", "standard": "autonomous", "yolo": "yolo"}
+FIELDS = set(DEFAULT)
+
+
+class ProfileError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ProfileError(message)
+
+
+def root_path(raw: str) -> Path:
+    root = Path(raw)
+    if not root.is_absolute() or not root.is_dir():
+        fail("--root must be an existing absolute directory")
+    return root.resolve()
+
+
+def normalize_extensions(value: Any) -> list[str]:
+    if not isinstance(value, list) or not value:
+        fail("extensions must be a nonempty array")
+    if any(not isinstance(item, str) or item not in EXTENSIONS for item in value):
+        fail("extensions contains an unknown extension")
+    enabled = set(value)
+    if "spex" not in enabled:
+        fail("extensions must include spex")
+    for extension, required in DEPENDENCIES.items():
+        if extension in enabled:
+            enabled.update(required)
+    order = list(DEFAULT["extensions"]) + [
+        "spex-teams", "spex-collab", "spex-detach"
+    ]
+    return [extension for extension in order if extension in enabled]
+
+
+def validate(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail("configuration must be a JSON object")
+    missing = FIELDS - set(value)
+    extra = set(value) - FIELDS
+    if missing:
+        fail(f"configuration is missing: {', '.join(sorted(missing))}")
+    if extra:
+        fail(f"configuration contains unknown fields: {', '.join(sorted(extra))}")
+    if value["schema_version"] != 1:
+        fail("schema_version must be 1")
+    if value["harness"] not in HARNESSES:
+        fail("harness must be auto, claude, codex, or opencode")
+    if value["security"] not in SECURITY:
+        fail("security must be safe, autonomous, or yolo")
+    return {
+        "schema_version": 1,
+        "harness": value["harness"],
+        "extensions": normalize_extensions(value["extensions"]),
+        "security": value["security"],
+    }
+
+
+def read_json(stream) -> dict[str, Any]:
+    try:
+        return json.load(stream)
+    except json.JSONDecodeError as error:
+        fail(f"invalid JSON: {error.msg}")
+
+
+def load(root: Path) -> dict[str, Any] | None:
+    path = root / PROFILE
+    if not path.exists():
+        return None
+    try:
+        with path.open(encoding="utf-8") as stream:
+            return validate(read_json(stream))
+    except OSError as error:
+        fail(f"cannot read {path}: {error}")
+
+
+def emit(value: dict[str, Any]) -> None:
+    json.dump(value, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def parse_extension_argument(raw: str) -> list[str]:
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def resolve(args: argparse.Namespace) -> None:
+    root = root_path(args.root)
+    stored = load(root) or DEFAULT
+    security = args.security
+    if not security and args.legacy_permissions:
+        security = LEGACY_SECURITY[args.legacy_permissions]
+    candidate = {
+        "schema_version": 1,
+        "harness": args.harness or stored["harness"],
+        "extensions": (
+            ["spex", *parse_extension_argument(args.extensions)]
+            if args.extensions else stored["extensions"]
+        ),
+        "security": security or stored["security"],
+    }
+    emit(validate(candidate))
+
+
+def persist(args: argparse.Namespace) -> None:
+    root = root_path(args.root)
+    value = validate(read_json(sys.stdin))
+    destination = root / PROFILE
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, raw_temporary = tempfile.mkstemp(
+        dir=destination.parent, prefix=".spex.", suffix=".tmp"
+    )
+    temporary = Path(raw_temporary)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    emit(value)
+
+
+def validate_command(args: argparse.Namespace) -> None:
+    root_path(args.root)
+    emit(validate(read_json(sys.stdin)))
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    commands = result.add_subparsers(required=True)
+    resolve_parser = commands.add_parser("resolve")
+    resolve_parser.add_argument("--root", required=True)
+    resolve_parser.add_argument("--harness", choices=sorted(HARNESSES), default="")
+    resolve_parser.add_argument("--extensions", default="")
+    resolve_parser.add_argument("--security", choices=sorted(SECURITY), default="")
+    resolve_parser.add_argument(
+        "--legacy-permissions", choices=sorted(LEGACY_SECURITY), default=""
+    )
+    resolve_parser.set_defaults(handler=resolve)
+    persist_parser = commands.add_parser("persist")
+    persist_parser.add_argument("--root", required=True)
+    persist_parser.set_defaults(handler=persist)
+    validate_parser = commands.add_parser("validate")
+    validate_parser.add_argument("--root", required=True)
+    validate_parser.set_defaults(handler=validate_command)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    args.handler(args)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ProfileError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/spex/setup.yml
+++ b/spex/setup.yml
@@ -10,16 +10,16 @@ workflow:
 inputs:
   integration:
     type: string
-    default: "auto"
+    default: ""
     prompt: "Agent harness (auto, claude, codex, opencode)"
   extensions:
     type: string
-    default: "all"
-    prompt: "Extensions to enable (all, interactive, or comma-separated list)"
-  permissions:
+    default: ""
+    prompt: "Extensions to enable (recommended, all, interactive, or comma-separated list)"
+  security:
     type: string
-    default: "standard"
-    prompt: "Permission level (standard, yolo, none)"
+    default: ""
+    prompt: "Requested security (safe, autonomous, yolo, or interactive)"
 
 steps:
   - id: check-version
@@ -78,10 +78,27 @@ steps:
       echo "or ensure network access to github.com is available." >&2
       exit 1
 
+  - id: resolve-request
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      TOOL="$SOURCE/scripts/spex-setup-profile.py"
+      [ -x "$TOOL" ] || { echo "ERROR: setup profile utility unavailable: $TOOL" >&2; exit 1; }
+      set -- resolve --root "$(pwd)"
+      INTEGRATION="{{ inputs.integration }}"
+      EXTENSIONS="{{ inputs.extensions }}"
+      SECURITY="{{ inputs.security }}"
+      [ -z "$INTEGRATION" ] || set -- "$@" --harness "$INTEGRATION"
+      case "$EXTENSIONS" in ""|interactive|recommended|all) ;; *) set -- "$@" --extensions "$EXTENSIONS" ;; esac
+      case "$SECURITY" in ""|interactive) ;; *) set -- "$@" --security "$SECURITY" ;; esac
+      "$TOOL" "$@"
+
   - id: detect-agent
     type: shell
     run: |
+      REQUEST='{{ steps.resolve-request.output.stdout }}'
       INPUT="{{ inputs.integration }}"
+      [ -n "$INPUT" ] || INPUT=$(printf '%s' "$REQUEST" | jq -r '.harness')
       case "$INPUT" in
         auto) ;;
         claude|codex|opencode) printf "%s" "$INPUT"; exit 0 ;;
@@ -218,10 +235,26 @@ steps:
       specify extension add "$EXT_PATH" $DEV_FLAG
       specify extension disable "$EXT" 2>/dev/null || true
 
+  - id: extension-mode
+    type: shell
+    run: |
+      INPUT="{{ inputs.extensions }}"
+      if [ -n "$INPUT" ]; then
+        printf "%s" "$INPUT"
+      elif [ -f .specify/spex.json ]; then
+        printf '%s' '{{ steps.resolve-request.output.stdout }}' | jq -r '.extensions | join(",")'
+      else
+        printf "interactive"
+      fi
+
   - id: select-extensions
     type: switch
-    expression: "{{ inputs.extensions }}"
+    expression: "{{ steps.extension-mode.output.stdout }}"
     cases:
+      recommended:
+        - id: ext-recommended-noop
+          type: shell
+          run: printf "recommended"
       all:
         - id: ext-all-noop
           type: shell
@@ -288,7 +321,7 @@ steps:
       - id: ext-filter
         type: shell
         run: |
-          SELECTION="{{ inputs.extensions }}"
+          SELECTION="{{ steps.extension-mode.output.stdout }}"
           OPTIONAL_EXTS="spex-gates spex-worktrees spex-deep-review spex-teams spex-collab spex-detach"
           GATES_DEPENDENTS="spex-teams spex-deep-review spex-collab"
           ENABLED_LIST=$(echo "$SELECTION" | tr ',' ' ')
@@ -329,6 +362,84 @@ steps:
             fi
           done
           printf "ok"
+
+  - id: selected-extensions
+    type: shell
+    run: |
+      MODE="{{ steps.extension-mode.output.stdout }}"
+      case "$MODE" in
+        interactive)
+          SELECTION="{{ steps.ext-interactive-prompt.output.stdout | default('') }}"
+          SELECTION=$(printf '%s' "$SELECTION" | tr -d '"')
+          [ -n "$SELECTION" ] || SELECTION="spex-gates,spex-worktrees,spex-deep-review"
+          [ "$SELECTION" != "all" ] || SELECTION="spex-gates,spex-worktrees,spex-deep-review,spex-teams,spex-collab,spex-detach"
+          ;;
+        recommended) SELECTION="spex-gates,spex-worktrees,spex-deep-review" ;;
+        all) SELECTION="spex-gates,spex-worktrees,spex-deep-review,spex-teams,spex-collab,spex-detach" ;;
+        *) SELECTION="$MODE" ;;
+      esac
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      "$SOURCE/scripts/spex-setup-profile.py" resolve --root "$(pwd)" \
+        --extensions "spex,$SELECTION" | jq -r '.extensions | join(",")'
+
+  - id: security-mode
+    type: shell
+    run: |
+      INPUT="{{ inputs.security }}"
+      if [ -n "$INPUT" ]; then
+        printf "%s" "$INPUT"
+      elif [ -f .specify/spex.json ]; then
+        printf '%s' '{{ steps.resolve-request.output.stdout }}' | jq -r '.security'
+      else
+        printf "interactive"
+      fi
+
+  - id: select-security
+    type: switch
+    expression: "{{ steps.security-mode.output.stdout }}"
+    cases:
+      interactive:
+        - id: security-interactive-prompt
+          type: prompt
+          prompt: >-
+            Select requested project security. Safe (recommended) preserves the
+            host policy. Autonomous reduces prompts for enumerated Spex project
+            operations. YOLO requests the broadest project-local autonomy the
+            active harness can safely express. Reply: safe, autonomous, or yolo.
+          integration: "{{ steps.detect-agent.output.stdout }}"
+    default:
+      - id: security-noop
+        type: shell
+        run: printf "ok"
+
+  - id: selected-security
+    type: shell
+    run: |
+      MODE="{{ steps.security-mode.output.stdout }}"
+      if [ "$MODE" = "interactive" ]; then
+        SELECTED="{{ steps.security-interactive-prompt.output.stdout | default('safe') }}"
+        SELECTED=$(printf '%s' "$SELECTED" | tr -d '"[:space:]')
+        [ -n "$SELECTED" ] || SELECTED="safe"
+      else
+        SELECTED="$MODE"
+      fi
+      SELECTED=$(printf '%s' "$SELECTED" | tr -d '"[:space:]')
+      case "$SELECTED" in safe|autonomous|yolo) printf "%s" "$SELECTED" ;;
+        *) echo "ERROR: Unknown security '$SELECTED'. Use safe, autonomous, or yolo" >&2; exit 1 ;;
+      esac
+
+  - id: persist-request
+    type: shell
+    run: |
+      SOURCE="{{ steps.locate-source.output.stdout }}"
+      TOOL="$SOURCE/scripts/spex-setup-profile.py"
+      HARNESS=$(printf '%s' '{{ steps.resolve-request.output.stdout }}' | jq -r '.harness')
+      "$TOOL" resolve --root "$(pwd)" --harness "$HARNESS" \
+        --extensions "{{ steps.selected-extensions.output.stdout }}" \
+        --security "{{ steps.selected-security.output.stdout }}" |
+        "$TOOL" persist --root "$(pwd)" >/dev/null
+      echo "Saved requested setup to .specify/spex.json" >&2
+      printf "ok"
 
   - id: adapt-commands
     type: shell
@@ -457,7 +568,7 @@ steps:
 
   - id: configure-permissions
     type: if
-    condition: "{{ inputs.permissions }} != 'none'"
+    condition: "{{ steps.selected-security.output.stdout }} != 'safe'"
     then:
       - id: permissions-dispatch
         type: switch
@@ -467,7 +578,7 @@ steps:
             - id: claude-permissions
               type: shell
               run: |
-                LEVEL="{{ inputs.permissions }}"
+                LEVEL="{{ steps.selected-security.output.stdout }}"
                 SETTINGS=".claude/settings.json"
                 mkdir -p .claude
 
@@ -526,12 +637,22 @@ steps:
           sed -i.bak '/.specify\/.spex-phase/d;/.specify\/.spex-state/d;/.claude\/skills\//d;/.claude\/settings\.local\.json/d' "$GITIGNORE" && rm -f "$GITIGNORE.bak"
         fi
       fi
-      [ -f "$GITIGNORE" ] && grep -qF "$SENTINEL" "$GITIGNORE" 2>/dev/null && exit 0
+      if [ -f "$GITIGNORE" ] && grep -qF "$SENTINEL" "$GITIGNORE" 2>/dev/null; then
+        for pattern in '**/.claude/' '**/.agents/' '**/.codex/' '**/.specify/**' \
+          '!**/.specify/spex.json' '!**/.specify/memory/' \
+          '!**/.specify/memory/constitution.md'; do
+          grep -qxF -- "$pattern" "$GITIGNORE" 2>/dev/null || printf '%s\n' "$pattern" >> "$GITIGNORE"
+        done
+        exit 0
+      fi
       cat >> "$GITIGNORE" << 'GIEOF'
 
       # spex: generated/local files (only constitution is committed)
       **/.claude/
+      **/.agents/
+      **/.codex/
       **/.specify/**
+      !**/.specify/spex.json
       !**/.specify/memory/
       !**/.specify/memory/constitution.md
       GIEOF

--- a/spex/setup.yml
+++ b/spex/setup.yml
@@ -20,6 +20,10 @@ inputs:
     type: string
     default: ""
     prompt: "Requested security (safe, autonomous, yolo, or interactive)"
+  permissions:
+    type: string
+    default: ""
+    prompt: "Deprecated security alias (none, standard, or yolo)"
 
 steps:
   - id: check-version
@@ -88,9 +92,13 @@ steps:
       INTEGRATION="{{ inputs.integration }}"
       EXTENSIONS="{{ inputs.extensions }}"
       SECURITY="{{ inputs.security }}"
+      LEGACY_PERMISSIONS="{{ inputs.permissions }}"
       [ -z "$INTEGRATION" ] || set -- "$@" --harness "$INTEGRATION"
       case "$EXTENSIONS" in ""|interactive|recommended|all) ;; *) set -- "$@" --extensions "$EXTENSIONS" ;; esac
       case "$SECURITY" in ""|interactive) ;; *) set -- "$@" --security "$SECURITY" ;; esac
+      if [ -z "$SECURITY" ] && [ -n "$LEGACY_PERMISSIONS" ]; then
+        set -- "$@" --legacy-permissions "$LEGACY_PERMISSIONS"
+      fi
       "$TOOL" "$@"
 
   - id: detect-agent
@@ -386,8 +394,16 @@ steps:
     type: shell
     run: |
       INPUT="{{ inputs.security }}"
+      LEGACY="{{ inputs.permissions }}"
       if [ -n "$INPUT" ]; then
         printf "%s" "$INPUT"
+      elif [ -n "$LEGACY" ]; then
+        case "$LEGACY" in
+          none) printf "safe" ;;
+          standard) printf "autonomous" ;;
+          yolo) printf "yolo" ;;
+          *) echo "ERROR: Unknown deprecated permissions '$LEGACY'. Use none, standard, or yolo" >&2; exit 1 ;;
+        esac
       elif [ -f .specify/spex.json ]; then
         printf '%s' '{{ steps.resolve-request.output.stdout }}' | jq -r '.security'
       else

--- a/tests/fixtures/setup-profile/invalid.json
+++ b/tests/fixtures/setup-profile/invalid.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "harness": "unknown",
+  "extensions": ["spex-teams"],
+  "security": "unsafe"
+}

--- a/tests/fixtures/setup-profile/valid.json
+++ b/tests/fixtures/setup-profile/valid.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "harness": "codex",
+  "extensions": ["spex", "spex-gates", "spex-worktrees"],
+  "security": "autonomous"
+}

--- a/tests/test_generated_trees.sh
+++ b/tests/test_generated_trees.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+tracked_generated() {
+  git -C "$1" ls-files | awk '
+    /^\.agents\// || /^\.codex\// || /^\.claude\/skills\// { print }
+  '
+}
+
+for generated in \
+  .agents/skills/example/SKILL.md \
+  .codex/hooks.json \
+  .claude/skills/example/SKILL.md; do
+  if ! git -C "$REPO_ROOT" check-ignore -q "$generated"; then
+    echo "FAIL: generated path is not ignored: $generated" >&2
+    exit 1
+  fi
+done
+
+if git -C "$REPO_ROOT" check-ignore -q .specify/spex.json; then
+  echo "FAIL: team-owned .specify/spex.json is ignored" >&2
+  exit 1
+fi
+
+tracked="$(tracked_generated "$REPO_ROOT")"
+if [[ -n "$tracked" ]]; then
+  echo "FAIL: generated harness artifacts are tracked:" >&2
+  printf '%s\n' "$tracked" >&2
+  echo "Edit canonical sources under spex/ instead." >&2
+  exit 1
+fi
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/spex-generated-guard.XXXXXX")"
+trap 'rm -rf -- "$fixture"' EXIT
+git -C "$fixture" init -q
+cp "$REPO_ROOT/.gitignore" "$fixture/.gitignore"
+mkdir -p "$fixture/.agents/skills/generated"
+printf '%s\n' generated > "$fixture/.agents/skills/generated/SKILL.md"
+git -C "$fixture" add -f .agents/skills/generated/SKILL.md
+if [[ -z "$(tracked_generated "$fixture")" ]]; then
+  echo "FAIL: guard fixture did not detect a force-tracked generated skill" >&2
+  exit 1
+fi
+
+echo "PASS: generated harness trees are ignored and tracked copies are rejected"

--- a/tests/test_setup_profile.py
+++ b/tests/test_setup_profile.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Contract tests for the team-owned Spex setup declaration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "spex/scripts/spex-setup-profile.py"
+FIXTURES = ROOT / "tests/fixtures/setup-profile"
+
+
+class SetupProfileTests(unittest.TestCase):
+    def run_tool(self, *args: str, cwd: Path, input_value=None, success=True):
+        payload = None if input_value is None else json.dumps(input_value)
+        result = subprocess.run(
+            ["python3", str(TOOL), *args], cwd=cwd, input=payload,
+            capture_output=True, text=True, check=False,
+        )
+        if success:
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return json.loads(result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        return result.stderr
+
+    def test_defaults_are_recommended_and_safe(self):
+        with tempfile.TemporaryDirectory() as raw:
+            resolved = self.run_tool("resolve", "--root", raw, cwd=Path(raw))
+        self.assertEqual(resolved["harness"], "auto")
+        self.assertEqual(resolved["security"], "safe")
+        self.assertEqual(
+            resolved["extensions"],
+            ["spex", "spex-gates", "spex-worktrees", "spex-deep-review"],
+        )
+
+    def test_stored_intent_is_reused_and_explicit_values_win(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            stored = json.loads((FIXTURES / "valid.json").read_text())
+            self.run_tool("persist", "--root", raw, cwd=root, input_value=stored)
+            reused = self.run_tool("resolve", "--root", raw, cwd=root)
+            overridden = self.run_tool(
+                "resolve", "--root", raw, "--harness", "claude",
+                "--extensions", "spex,spex-collab", "--security", "yolo", cwd=root,
+            )
+        self.assertEqual(reused, stored)
+        self.assertEqual(overridden["harness"], "claude")
+        self.assertEqual(overridden["security"], "yolo")
+        self.assertEqual(overridden["extensions"], ["spex", "spex-gates", "spex-collab"])
+
+    def test_validation_rejects_unknowns_and_normalizes_dependencies(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            normalized = self.run_tool(
+                "resolve", "--root", raw, "--extensions", "spex-teams,spex", cwd=root
+            )
+            error = self.run_tool(
+                "validate", "--root", raw, cwd=root,
+                input_value=json.loads((FIXTURES / "invalid.json").read_text()), success=False,
+            )
+        self.assertEqual(normalized["extensions"], ["spex", "spex-gates", "spex-teams"])
+        self.assertIn("harness", error)
+
+    def test_failure_is_byte_identical_and_persistence_is_atomic(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            valid = json.loads((FIXTURES / "valid.json").read_text())
+            self.run_tool("persist", "--root", raw, cwd=root, input_value=valid)
+            path = root / ".specify/spex.json"
+            before = hashlib.sha256(path.read_bytes()).digest()
+            self.run_tool(
+                "persist", "--root", raw, cwd=root,
+                input_value={**valid, "security": "unsafe"}, success=False,
+            )
+            after = hashlib.sha256(path.read_bytes()).digest()
+            temporary = list(path.parent.glob(".spex.*.tmp"))
+        self.assertEqual(before, after)
+        self.assertEqual(temporary, [])
+
+    def test_legacy_permission_names_migrate(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            safe = self.run_tool(
+                "resolve", "--root", raw, "--legacy-permissions", "none", cwd=root
+            )
+            autonomous = self.run_tool(
+                "resolve", "--root", raw, "--legacy-permissions", "standard", cwd=root
+            )
+        self.assertEqual(safe["security"], "safe")
+        self.assertEqual(autonomous["security"], "autonomous")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_setup.sh
+++ b/tests/test_workflow_setup.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 TEST_REPO="$(mktemp -d "${TMPDIR:-/tmp}/spex-workflow-setup.XXXXXX")"
-trap 'rm -rf -- "$TEST_REPO"' EXIT
+LEGACY_REPO="$(mktemp -d "${TMPDIR:-/tmp}/spex-workflow-legacy.XXXXXX")"
+trap 'rm -rf -- "$TEST_REPO" "$LEGACY_REPO"' EXIT
 git -C "$TEST_REPO" init -q
+git -C "$LEGACY_REPO" init -q
 
 run_setup() {
   (
@@ -32,9 +34,17 @@ jq -e '.status == "completed"' <<<"$refresh" >/dev/null
 after="$(shasum -a 256 "$profile" | awk '{print $1}')"
 [[ "$before" == "$after" ]]
 
+legacy="$({
+  cd "$LEGACY_REPO"
+  SPEX_SOURCE="$REPO_ROOT/spex" specify workflow run "$REPO_ROOT/spex/setup.yml" --json \
+    -i integration=claude -i extensions=recommended -i permissions=standard
+})"
+jq -e '.status == "completed"' <<<"$legacy" >/dev/null
+jq -e '.security == "autonomous"' "$LEGACY_REPO/.specify/spex.json" >/dev/null
+
 if find "$TEST_REPO" -maxdepth 2 -type d -name '*materializ*' | grep -q .; then
   echo "FAIL: workflow setup created a staged distribution" >&2
   exit 1
 fi
 
-echo "PASS: workflow setup persists intent and refreshes without materialization"
+echo "PASS: workflow setup persists intent, migrates legacy permissions, and refreshes without materialization"

--- a/tests/test_workflow_setup.sh
+++ b/tests/test_workflow_setup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TEST_REPO="$(mktemp -d "${TMPDIR:-/tmp}/spex-workflow-setup.XXXXXX")"
+trap 'rm -rf -- "$TEST_REPO"' EXIT
+git -C "$TEST_REPO" init -q
+
+run_setup() {
+  (
+    cd "$TEST_REPO"
+    SPEX_SOURCE="$REPO_ROOT/spex" specify workflow run "$REPO_ROOT/spex/setup.yml" --json "$@"
+  )
+}
+
+initial="$(run_setup \
+  -i integration=claude \
+  -i extensions=spex-gates,spex-worktrees \
+  -i security=autonomous)"
+jq -e '.status == "completed"' <<<"$initial" >/dev/null
+
+profile="$TEST_REPO/.specify/spex.json"
+jq -e '
+  .schema_version == 1 and .harness == "claude" and
+  .security == "autonomous" and
+  .extensions == ["spex", "spex-gates", "spex-worktrees"]
+' "$profile" >/dev/null
+before="$(shasum -a 256 "$profile" | awk '{print $1}')"
+
+refresh="$(run_setup)"
+jq -e '.status == "completed"' <<<"$refresh" >/dev/null
+after="$(shasum -a 256 "$profile" | awk '{print $1}')"
+[[ "$before" == "$after" ]]
+
+if find "$TEST_REPO" -maxdepth 2 -type d -name '*materializ*' | grep -q .; then
+  echo "FAIL: workflow setup created a staged distribution" >&2
+  exit 1
+fi
+
+echo "PASS: workflow setup persists intent and refreshes without materialization"


### PR DESCRIPTION
## Summary

- add a checked-in `.specify/spex.json` declaration for harness, extensions, and security intent
- make setup repeatable and prompt-free after the initial configuration
- keep Claude development source-transparent while treating `.agents/` and `.codex/` as generated outputs
- add schema, migration, generated-tree safeguards, tests, and review guidance

## Design note: JSON is intentional

The initial discussion used `.specify/spex.yml` illustratively. This PR deliberately uses `.specify/spex.json`: setup already requires `jq`, Python 3.9 supports JSON in the standard library, and this avoids adding `yq`, PyYAML, `tomllib`, or a partial parser. The rationale is recorded in `research.md`.

## Compatibility

The deprecated `permissions` input remains supported: `none` maps to `safe`, `standard` to `autonomous`, and `yolo` remains `yolo`. Explicit `security` takes precedence.

## Scope boundaries

This PR deliberately excludes Codex hook adaptation, marketplace packaging, state transfer, recovery/progress, and Teams orchestration. Those are independently reviewable follow-ups. The OpenCode delivery threshold is tracked in #48.

## Validation

- `make test-setup-profile`
- `make test-workflow-setup`
- `make test-generated-trees`
- `make validate`
- `make sync-scripts-check`
- `make test-install` (39 passed)
- JSON Schema metaschema and fixture validation
- `git diff --check`

## Review focus

Please use `specs/048-workflow-first-setup/REVIEWERS.md`, especially the Claude source-transparency and scope checks. Do not merge until the focused cross-harness review is complete.