### PR TITLE
feat: configure native Codex projects

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/046-smart-phase-splitting"
+  "feature_directory": "specs/049-codex-native-integration"
 }

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ validate:
 test-setup-profile:
 	python3 -m unittest tests/test_setup_profile.py
 
+test-codex-project:
+	python3 -m unittest tests/test_codex_project.py
+
 test-workflow-setup:
 	@tests/test_workflow_setup.sh
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Why cc-spex?
 
-[Spec-Kit](https://github.com/github/spec-kit) is a great foundation for specification-driven development. cc-spex is a Claude Code plugin that extends Spec-Kit through **extensions**, self-contained bundles that provide additional commands and lifecycle hooks.
+[Spec-Kit](https://github.com/github/spec-kit) is a great foundation for specification-driven development. cc-spex extends Spec-Kit across Claude Code and Codex through **extensions**, self-contained bundles that provide additional skills, commands, and lifecycle hooks where the harness supports them.
 
 Six bundled extensions add quality gates, git worktree isolation, parallel agent execution, multi-perspective code review, and collaborative PR workflows. Each extension registers hooks that fire automatically at spec-kit lifecycle boundaries. You enable or disable them independently via `specify extension enable/disable`.
 
@@ -128,6 +128,8 @@ For smaller features or solo work where intermediate review is not needed, `/spe
 
 ```mermaid
 flowchart TD
+    Setup["specify workflow run spex/setup.yml"] --> Harness["Detect harness + install extensions<br>apply project guidance and security"]
+    Harness --> Start
     Start([Idea]) --> HasClarity{Clear<br>requirements?}
 
     HasClarity -->|Not yet| Brainstorm["/speckit-spex-brainstorm<br>Refine idea"]
@@ -234,6 +236,15 @@ permission policy untouched.
 The active harness adapter remains responsible for applying or safely degrading that
 request.
 
+Codex setup writes only sentinel-owned sections. It merges `$`-prefixed Spex
+skill guidance into `AGENTS.md` and, for Autonomous or YOLO, a named
+`spex-project` permission profile into `.codex/config.toml`. Safe removes no
+user policy. Autonomous routes boundary requests to auto-review. Bounded YOLO
+uses `approval_policy = "never"`, permits the workspace, temporary directories,
+and linked-worktree Git metadata, and keeps command network access disabled.
+Setup refuses conflicting user-owned permission selectors rather than replacing
+them.
+
 The former `permissions` workflow input remains available as a deprecated alias:
 `none` maps to `safe`, `standard` maps to `autonomous`, and `yolo` remains
 `yolo`. When both inputs are supplied, `security` takes precedence.
@@ -255,7 +266,7 @@ cc-spex uses spec-kit's native extension system. Each extension lives in `spex/e
 
 ### Bundled Extensions
 
-**`spex`** (core, always active): Brainstorming, ship pipeline, help, evolve, spec refactoring, flow state tracking, focused interactive smoke test (curated scenarios from spec's `## Smoke Test` section), submit (PR creation + watch mode), finish (smoke test gate + squash + merge), and lifecycle hooks (flow state cleanup via `after_finish`).
+**`spex`** (core, always active): Brainstorming, ship pipeline, help, evolve, spec refactoring, flow state tracking, focused interactive smoke test (curated scenarios from spec's `## Smoke Test` section), submit (PR creation + watch mode), finish (smoke test gate + squash + merge), and lifecycle hooks where supported (flow state cleanup via `after_finish`). Codex setup also installs concise `$skill` guidance without overwriting team-owned `AGENTS.md` content.
 
 **`spex-gates`**: Quality gates that fire automatically via lifecycle hooks:
 - `after_specify`: runs spec review
@@ -292,10 +303,12 @@ Extension state is tracked in `.specify/extensions/.registry`.
 
 ### Workflow Commands
 
-These are the commands you'll use day-to-day. The `/speckit-*` commands come from Spec-Kit. Extension commands use the `/speckit-spex-*` prefix and are registered after `/spex:init`.
+These are the commands you'll use day-to-day. Claude Code invokes them with `/`;
+Codex invokes generated skills with `$` (for example, `$speckit-plan`).
 
 | Command | Purpose |
 |---------|---------|
+| `specify workflow run spex/setup.yml` | Install or refresh Spex for the selected harness |
 | `/speckit-specify` | Define requirements and create a formal spec |
 | `/speckit-plan` | Generate an implementation plan from a spec |
 | `/speckit-tasks` | Create actionable tasks from a plan |
@@ -477,7 +490,7 @@ spex supports multiple AI coding agents beyond Claude Code. The enforcement mode
 | Agent | Tool Gating | Prompt Interception | Interactive Prompts | Parallel Dispatch |
 |-------|------------|--------------------|--------------------|------------------|
 | **Claude Code** | PreToolUse hooks | UserPromptSubmit hooks | AskUserQuestion | Agent tool (teams) |
-| **Codex CLI** | PreToolUse hooks | UserPromptSubmit hooks | Inline numbered list | Subagents |
+| **Codex CLI** | Not installed by project setup | Not installed by project setup | Inline numbered list | Subagents |
 | **OpenCode** | TypeScript plugin | Skill preambles | question tool | Task tool |
 
 ### Architecture
@@ -492,7 +505,7 @@ Extensions degrade gracefully on agents with fewer capabilities:
 
 | Extension | Claude Code | Codex / OpenCode |
 |-----------|------------|-----------------|
-| spex-gates | Full enforcement | Full enforcement |
+| spex-gates | Full enforcement | Skills available; project hooks deferred |
 | spex-collab | Full functionality | Full functionality |
 | spex-teams | Parallel via Agent Teams | Sequential fallback |
 | spex-worktrees | EnterWorktree tool | Manual git worktree commands |
@@ -601,6 +614,7 @@ All `/speckit-*` commands remain unchanged.
 
 ```bash
 make validate          # Validate plugin and marketplace schemas
+make test-codex-project  # Test Codex guidance, security profiles, and linked worktrees
 make test-install      # Integration test: install from local marketplace
 make test-install-remote  # Integration test: install from GitHub marketplace
 make release           # Full release: validate, update marketplace.json, tag, push, bump to dev

--- a/README.md
+++ b/README.md
@@ -226,7 +226,11 @@ same harness preference, extension selection, and requested security:
 Explicit workflow inputs override stored values and update the declaration only
 after validation. Without explicit inputs, setup reuses it. Safe is recommended;
 Autonomous and YOLO request progressively broader project-local autonomy. The
-active harness adapter remains responsible for applying or safely degrading that
+Codex mapping merges `$skill` guidance into `AGENTS.md`. Its bounded YOLO profile
+allows workspace, temporary-directory, and shared Git metadata writes without
+prompts while command network access remains disabled. Safe leaves user Codex
+permission policy untouched.
+The active harness adapter remains responsible for applying or safely degrading that
 request.
 
 The former `permissions` workflow input remains available as a deprecated alias:

--- a/README.md
+++ b/README.md
@@ -227,23 +227,25 @@ same harness preference, extension selection, and requested security:
 
 Explicit workflow inputs override stored values and update the declaration only
 after validation. Without explicit inputs, setup reuses it. Safe is recommended;
-Autonomous and YOLO request progressively broader project-local autonomy. The
-Codex mapping merges `$skill` guidance into `AGENTS.md`. Its bounded YOLO profile
-allows workspace, temporary-directory, and shared Git metadata writes without
-prompts while command network access remains disabled. Safe leaves user Codex
-permission policy untouched.
+Autonomous requests bounded project autonomy, while YOLO is explicitly
+unrestricted. The Codex mapping merges `$skill` guidance into `AGENTS.md`. YOLO
+uses the `danger-full-access` sandbox with approvals disabled, including
+unrestricted filesystem and network access. Safe leaves user Codex permission
+policy untouched.
 
 The active harness adapter remains responsible for applying or safely degrading that
 request.
 
 Codex setup writes only sentinel-owned sections. It merges `$`-prefixed Spex
-skill guidance into `AGENTS.md` and, for Autonomous or YOLO, a named
-`spex-project` permission profile into `.codex/config.toml`. Safe removes no
-user policy. Autonomous routes boundary requests to auto-review. Bounded YOLO
-uses `approval_policy = "never"`, permits the workspace, temporary directories,
-and linked-worktree Git metadata, and keeps command network access disabled.
-Setup refuses conflicting user-owned permission selectors rather than replacing
-them.
+skill guidance into `AGENTS.md`. Safe removes no user policy. Autonomous writes
+a named `spex-project` permission profile to `.codex/config.toml`, explicitly
+uses `approval_policy = "on-request"`, and routes boundary requests to
+`approvals_reviewer = "auto_review"`; its bounded profile permits the workspace,
+temporary directories, and linked-worktree Git metadata while disabling command
+network access. YOLO instead writes `sandbox_mode = "danger-full-access"` with
+`approval_policy = "never"`, allowing unrestricted filesystem and network access
+without prompts. Setup refuses conflicting user-owned permission selectors
+rather than replacing them.
 
 The former `permissions` workflow input remains available as a deprecated alias:
 `none` maps to `safe`, `standard` maps to `autonomous`, and `yolo` remains

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Codex mapping merges `$skill` guidance into `AGENTS.md`. Its bounded YOLO profil
 allows workspace, temporary-directory, and shared Git metadata writes without
 prompts while command network access remains disabled. Safe leaves user Codex
 permission policy untouched.
+
 The active harness adapter remains responsible for applying or safely degrading that
 request.
 

--- a/specs/049-codex-native-integration/REVIEWERS.md
+++ b/specs/049-codex-native-integration/REVIEWERS.md
@@ -2,8 +2,10 @@
 
 Review this stacked PR against `048-workflow-first-setup`.
 
-- Confirm the permission profile matches current Codex configuration.
-- Confirm YOLO removes worktree Git prompts without command network.
+- Confirm Autonomous uses the bounded `spex-project` profile with on-request
+  auto-review, including linked-worktree Git metadata and disabled network.
+- Confirm YOLO uses `danger-full-access` with approvals set to `never`, including
+  unrestricted network access.
 - Confirm user `AGENTS.md` and `.codex/config.toml` content is preserved.
 - Confirm examples use `$`, and Claude behavior is unchanged.
 - Reject hooks, packaging, materialization, state/recovery, or Teams work.

--- a/specs/049-codex-native-integration/REVIEWERS.md
+++ b/specs/049-codex-native-integration/REVIEWERS.md
@@ -1,0 +1,9 @@
+# Review Guide: Native Codex Project Integration
+
+Review this stacked PR against `048-workflow-first-setup`.
+
+- Confirm the permission profile matches current Codex configuration.
+- Confirm YOLO removes worktree Git prompts without command network.
+- Confirm user `AGENTS.md` and `.codex/config.toml` content is preserved.
+- Confirm examples use `$`, and Claude behavior is unchanged.
+- Reject hooks, packaging, materialization, state/recovery, or Teams work.

--- a/specs/049-codex-native-integration/plan.md
+++ b/specs/049-codex-native-integration/plan.md
@@ -1,11 +1,12 @@
 # Implementation Plan: Native Codex Project Integration
 
 Use a Python standard-library configurator called by `spex/setup.yml`. It
-resolves the Git common directory, writes a current Codex named permission
-profile into a sentinel-owned `.codex/config.toml` block, and merges concise
-Codex guidance into `AGENTS.md`. Safe removes only Spex-owned permission data;
-Autonomous uses auto-review; YOLO uses `never`, so out-of-bound actions fail
-rather than interrupting the user.
+resolves the Git common directory for Autonomous, writes a sentinel-owned
+`.codex/config.toml` block, and merges concise Codex guidance into `AGENTS.md`.
+Safe removes only Spex-owned permission data. Autonomous uses the bounded
+`spex-project` profile with on-request auto-review. YOLO uses the unrestricted
+`danger-full-access` sandbox with `never`, so filesystem and network operations
+run without approval prompts.
 
 Project hooks are excluded. Codex plugins carry hooks natively, so project hook
 installation would duplicate ownership and trust review.

--- a/specs/049-codex-native-integration/plan.md
+++ b/specs/049-codex-native-integration/plan.md
@@ -1,0 +1,11 @@
+# Implementation Plan: Native Codex Project Integration
+
+Use a Python standard-library configurator called by `spex/setup.yml`. It
+resolves the Git common directory, writes a current Codex named permission
+profile into a sentinel-owned `.codex/config.toml` block, and merges concise
+Codex guidance into `AGENTS.md`. Safe removes only Spex-owned permission data;
+Autonomous uses auto-review; YOLO uses `never`, so out-of-bound actions fail
+rather than interrupting the user.
+
+Project hooks are excluded. Codex plugins carry hooks natively, so project hook
+installation would duplicate ownership and trust review.

--- a/specs/049-codex-native-integration/research.md
+++ b/specs/049-codex-native-integration/research.md
@@ -1,0 +1,9 @@
+# Research: Current Codex Contracts
+
+The current official Codex manual establishes that named permission profiles use
+`default_permissions` plus `[permissions.*]`; worktree Git metadata can need an
+explicit writable root; `approval_policy = "never"` removes prompts; plugins can
+bundle hooks; and Codex supports explicit `$` mentions for skills.
+
+Decision: use current permission profiles and defer hooks to plugin packaging.
+Do not carry the old hook installer or `tomllib` dependency forward.

--- a/specs/049-codex-native-integration/research.md
+++ b/specs/049-codex-native-integration/research.md
@@ -1,9 +1,18 @@
 # Research: Current Codex Contracts
 
-The current official Codex manual establishes that named permission profiles use
-`default_permissions` plus `[permissions.*]`; worktree Git metadata can need an
-explicit writable root; `approval_policy = "never"` removes prompts; plugins can
-bundle hooks; and Codex supports explicit `$` mentions for skills.
+The current Codex configuration contract supports two distinct mappings needed
+here. Named permission profiles use `default_permissions` plus `[permissions.*]`,
+and linked-worktree Git metadata needs an explicit writable root when that
+profile is bounded. `approval_policy = "on-request"` with
+`approvals_reviewer = "auto_review"` preserves that boundary for Autonomous
+without routine user prompts.
 
-Decision: use current permission profiles and defer hooks to plugin packaging.
-Do not carry the old hook installer or `tomllib` dependency forward.
+For YOLO, `sandbox_mode = "danger-full-access"` removes the filesystem and
+network sandbox, while `approval_policy = "never"` removes approval prompts.
+Keeping the named profile in YOLO would contradict the requested unrestricted
+mode and could make unattended workflows fail at its boundary.
+
+Decision: use the bounded named profile only for Autonomous, use native
+danger-full-access plus never-approve settings for YOLO, preserve user policy in
+Safe, and defer hooks to plugin packaging. Do not carry the old hook installer
+or `tomllib` dependency forward. Codex supports explicit `$` mentions for skills.

--- a/specs/049-codex-native-integration/spec.md
+++ b/specs/049-codex-native-integration/spec.md
@@ -3,23 +3,30 @@
 ## Goal
 
 Make workflow-first Spex setup feel native in Codex without requiring a plugin
-or materialization. Preserve user files, use `$skill` syntax, and make trusted
-worktree Git operations prompt-free when YOLO is explicitly selected.
+or materialization. Preserve user files, use `$skill` syntax, keep Autonomous
+bounded, and make YOLO reliably prompt-free and unrestricted when explicitly
+selected.
 
 ## Requirements
 
 - **FR-001**: Merge a sentinel-owned block into `AGENTS.md`.
 - **FR-002**: Show `$...`, never `/...`, for Codex Spex skill invocation.
 - **FR-003**: Safe MUST leave user permission policy unchanged.
-- **FR-004**: Autonomous MUST use automatic review within bounded permissions.
-- **FR-005**: YOLO MUST be prompt-free for workspace, temp, and Git metadata.
-- **FR-006**: YOLO MUST keep command network disabled and fail closed beyond bounds.
+- **FR-004**: Autonomous MUST set `approval_policy = "on-request"` and
+  `approvals_reviewer = "auto_review"` within bounded `spex-project` permissions.
+- **FR-005**: YOLO MUST set `sandbox_mode = "danger-full-access"` and
+  `approval_policy = "never"` so filesystem and network access are unrestricted
+  and prompt-free.
+- **FR-006**: Safe MUST preserve existing user policy without adding a sandbox,
+  approval policy, or permission profile.
 - **FR-007**: Support linked worktrees and Python 3.9 without third-party TOML.
 - **FR-008**: Refresh MUST be byte-idempotent and preserve user content.
 - **FR-009**: This slice MUST NOT install hooks or package a plugin.
 
 ## Success Criteria
 
-- A linked worktree includes its Git common directory in its writable boundary.
+- Autonomous in a linked worktree includes its Git common directory in its
+  writable boundary and keeps command network access disabled.
+- YOLO works without a Git repository and permits network access without prompts.
 - Repeating setup changes neither generated config nor guidance bytes.
 - Existing workflow, generated-tree, and Claude manifest tests remain green.

--- a/specs/049-codex-native-integration/spec.md
+++ b/specs/049-codex-native-integration/spec.md
@@ -1,0 +1,25 @@
+# Feature Specification: Native Codex Project Integration
+
+## Goal
+
+Make workflow-first Spex setup feel native in Codex without requiring a plugin
+or materialization. Preserve user files, use `$skill` syntax, and make trusted
+worktree Git operations prompt-free when YOLO is explicitly selected.
+
+## Requirements
+
+- **FR-001**: Merge a sentinel-owned block into `AGENTS.md`.
+- **FR-002**: Show `$...`, never `/...`, for Codex Spex skill invocation.
+- **FR-003**: Safe MUST leave user permission policy unchanged.
+- **FR-004**: Autonomous MUST use automatic review within bounded permissions.
+- **FR-005**: YOLO MUST be prompt-free for workspace, temp, and Git metadata.
+- **FR-006**: YOLO MUST keep command network disabled and fail closed beyond bounds.
+- **FR-007**: Support linked worktrees and Python 3.9 without third-party TOML.
+- **FR-008**: Refresh MUST be byte-idempotent and preserve user content.
+- **FR-009**: This slice MUST NOT install hooks or package a plugin.
+
+## Success Criteria
+
+- A linked worktree includes its Git common directory in its writable boundary.
+- Repeating setup changes neither generated config nor guidance bytes.
+- Existing workflow, generated-tree, and Claude manifest tests remain green.

--- a/specs/049-codex-native-integration/tasks.md
+++ b/specs/049-codex-native-integration/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] T001 Define current Codex mappings and scope.
 - [x] T002 Implement Python 3.9-compatible sentinel merging.
-- [x] T003 Permit linked-worktree shared Git metadata.
+- [x] T003 Permit linked-worktree shared Git metadata under Autonomous.
 - [x] T004 Generate `$skill` guidance while preserving team rules.
 - [x] T005 Dispatch Codex setup through the workflow.
-- [x] T006 Test bounds, idempotency, cleanup, and regressions.
+- [x] T006 Test Autonomous bounds, unrestricted YOLO, idempotency, cleanup, and regressions.

--- a/specs/049-codex-native-integration/tasks.md
+++ b/specs/049-codex-native-integration/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Native Codex Project Integration
+
+- [x] T001 Define current Codex mappings and scope.
+- [x] T002 Implement Python 3.9-compatible sentinel merging.
+- [x] T003 Permit linked-worktree shared Git metadata.
+- [x] T004 Generate `$skill` guidance while preserving team rules.
+- [x] T005 Dispatch Codex setup through the workflow.
+- [x] T006 Test bounds, idempotency, cleanup, and regressions.

--- a/spex/scripts/configure-codex-project.py
+++ b/spex/scripts/configure-codex-project.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Atomically configure Spex guidance and permissions for a Codex project."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+
+CONFIG_BEGIN = "# >>> spex managed Codex permissions >>>"
+CONFIG_END = "# <<< spex managed Codex permissions <<<"
+GUIDANCE_BEGIN = "<!-- >>> spex managed Codex guidance >>>"
+GUIDANCE_END = "<!-- <<< spex managed Codex guidance <<< -->"
+
+
+class ConfigurationError(Exception):
+    """Refuse an unsafe or ambiguous project configuration change."""
+
+
+def absolute_root(raw):
+    """Return an existing absolute project directory."""
+    root = Path(raw)
+    if not root.is_absolute() or not root.is_dir():
+        raise argparse.ArgumentTypeError("--root must be an existing absolute directory")
+    return root.resolve()
+
+
+def git_common_dir(root):
+    """Resolve the shared Git metadata directory, including linked worktrees."""
+    result = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise ConfigurationError(result.stderr.strip() or "YOLO requires a Git repository")
+    path = Path(result.stdout.strip())
+    if not path.is_absolute():
+        path = root / path
+    return path.resolve(strict=True)
+
+
+def replace_block(existing, begin, end, replacement):
+    """Replace one managed block while preserving all user-owned content."""
+    if existing.count(begin) != existing.count(end) or existing.count(begin) > 1:
+        raise ConfigurationError("malformed Spex-managed block")
+    if begin not in existing:
+        if not existing:
+            return replacement.rstrip() + "\n"
+        separator = "\n" if existing.endswith("\n") else "\n\n"
+        return existing + separator + replacement.rstrip() + "\n"
+    if existing.index(begin) > existing.index(end):
+        raise ConfigurationError("malformed Spex-managed block")
+    pattern = re.compile(re.escape(begin) + r".*?" + re.escape(end), re.DOTALL)
+    updated, count = pattern.subn(replacement.rstrip(), existing)
+    if count != 1:
+        raise ConfigurationError("could not isolate Spex-managed block")
+    return updated
+
+
+def remove_block(existing, begin, end):
+    """Remove one managed block while preserving user-owned content."""
+    if existing.count(begin) != existing.count(end) or existing.count(begin) > 1:
+        raise ConfigurationError("malformed Spex-managed block")
+    if begin not in existing:
+        return existing
+    pattern = re.compile(r"(?:^|\n)" + re.escape(begin) + r".*?" + re.escape(end) + r"(?:\n|$)", re.DOTALL)
+    updated, count = pattern.subn("\n", existing)
+    if count != 1:
+        raise ConfigurationError("could not isolate Spex-managed block")
+    return updated.lstrip("\n")
+
+
+def merge_permissions(existing, block):
+    """Prepend managed root keys or refresh their existing owned block."""
+    if CONFIG_BEGIN in existing:
+        return replace_block(existing, CONFIG_BEGIN, CONFIG_END, block)
+    root_region = existing.split("\n[", 1)[0]
+    conflicts = []
+    for key in ("default_permissions", "approval_policy", "approvals_reviewer"):
+        if re.search(r"^\s*" + key + r"\s*=", root_region, re.MULTILINE):
+            conflicts.append(key)
+    if re.search(r"^\s*\[permissions\.spex-project(?:\.|\])", existing, re.MULTILINE):
+        conflicts.append("permissions.spex-project")
+    if conflicts:
+        raise ConfigurationError(
+            "refusing to override user-owned Codex settings: " + ", ".join(conflicts)
+        )
+    return block.rstrip() + "\n" + ("\n" + existing if existing else "")
+
+
+def permission_block(root, security):
+    """Render current Codex permission-profile configuration."""
+    if security == "safe":
+        return ""
+    common = json.dumps(str(git_common_dir(root)))
+    reviewer = 'approvals_reviewer = "auto_review"' if security == "autonomous" else 'approval_policy = "never"'
+    return "\n".join(
+        [
+            CONFIG_BEGIN,
+            '# Generated from .specify/spex.json; edit that declaration, not this block.',
+            'default_permissions = "spex-project"',
+            reviewer,
+            "",
+            '[permissions.spex-project.filesystem]',
+            '":minimal" = "read"',
+            '":tmpdir" = "write"',
+            '":slash_tmp" = "write"',
+            '":workspace_roots" = { "." = "write" }',
+            common + ' = "write"',
+            "",
+            "[permissions.spex-project.network]",
+            "enabled = false",
+            CONFIG_END,
+        ]
+    )
+
+
+def atomic_write(path, content):
+    """Replace a file atomically without changing its existing mode."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
+    descriptor, temporary = tempfile.mkstemp(dir=path.parent, prefix=".spex.")
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+
+
+def configure(args):
+    """Apply the selected security mapping and managed Codex guidance."""
+    config_path = args.root / ".codex" / "config.toml"
+    agents_path = args.root / "AGENTS.md"
+    template_path = Path(__file__).resolve().parent.parent / "templates" / "agents-md" / "codex.md"
+    config = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    guidance = agents_path.read_text(encoding="utf-8") if agents_path.exists() else ""
+    block = permission_block(args.root, args.security)
+    updated_config = (
+        merge_permissions(config, block)
+        if block
+        else remove_block(config, CONFIG_BEGIN, CONFIG_END)
+    )
+    template = template_path.read_text(encoding="utf-8")
+    updated_guidance = replace_block(guidance, GUIDANCE_BEGIN, GUIDANCE_END, template)
+    changes = []
+    if updated_config != config:
+        changes.append((config_path, updated_config))
+    if updated_guidance != guidance:
+        changes.append((agents_path, updated_guidance))
+    for path, content in changes:
+        atomic_write(path, content)
+    return {
+        "status": "configured",
+        "security": args.security,
+        "permissions": "unchanged" if args.security == "safe" else "spex-project",
+        "config_changed": updated_config != config,
+        "guidance_changed": updated_guidance != guidance,
+    }
+
+
+def main():
+    """Run the Codex project configurator."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, type=absolute_root)
+    parser.add_argument("--security", required=True, choices=("safe", "autonomous", "yolo"))
+    args = parser.parse_args()
+    try:
+        payload = configure(args)
+    except (ConfigurationError, OSError, subprocess.SubprocessError) as error:
+        payload = {"status": "refused", "error": str(error), "config_changed": False}
+        json.dump(payload, sys.stdout, sort_keys=True)
+        sys.stdout.write("\n")
+        return 1
+    json.dump(payload, sys.stdout, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spex/scripts/configure-codex-project.py
+++ b/spex/scripts/configure-codex-project.py
@@ -17,6 +17,12 @@ CONFIG_BEGIN = "# >>> spex managed Codex permissions >>>"
 CONFIG_END = "# <<< spex managed Codex permissions <<<"
 GUIDANCE_BEGIN = "<!-- >>> spex managed Codex guidance >>>"
 GUIDANCE_END = "<!-- <<< spex managed Codex guidance <<< -->"
+TOML_KEY_TOKEN = r'''(?:[A-Za-z0-9_-]+|"(?:\\["\\btnfr]|\\u[0-9A-Fa-f]{4}|\\U[0-9A-Fa-f]{8}|[^"\\])*"|'[^']*')'''
+ROOT_ASSIGNMENT = re.compile(r"^\s*(" + TOML_KEY_TOKEN + r")\s*=", re.MULTILINE)
+PROFILE_TABLE = re.compile(
+    r"^\s*\[\s*(" + TOML_KEY_TOKEN + r")\s*\.\s*(" + TOML_KEY_TOKEN + r")(?:\s*\.|\s*\])",
+    re.MULTILINE,
+)
 
 
 class ConfigurationError(Exception):
@@ -79,22 +85,50 @@ def remove_block(existing, begin, end):
     return updated.lstrip("\n")
 
 
+def decode_toml_key(token):
+    """Decode a bare, literal, or basic TOML key segment without third parties."""
+    if not token.startswith(('"', "'")):
+        return token
+    if token.startswith("'"):
+        return token[1:-1]
+    escapes = {'"': '"', "\\": "\\", "b": "\b", "t": "\t", "n": "\n", "f": "\f", "r": "\r"}
+    content = token[1:-1]
+    decoded = []
+    index = 0
+    while index < len(content):
+        if content[index] != "\\":
+            decoded.append(content[index])
+            index += 1
+            continue
+        marker = content[index + 1]
+        if marker in escapes:
+            decoded.append(escapes[marker])
+            index += 2
+            continue
+        digits = 4 if marker == "u" else 8
+        try:
+            decoded.append(chr(int(content[index + 2:index + 2 + digits], 16)))
+        except (ValueError, OverflowError):
+            return None
+        index += 2 + digits
+    return "".join(decoded)
+
+
 def merge_permissions(existing, block):
     """Prepend managed root keys or refresh their existing owned block."""
     if CONFIG_BEGIN in existing:
         return replace_block(existing, CONFIG_BEGIN, CONFIG_END, block)
-    root_region = existing.split("\n[", 1)[0]
+    root_region = re.split(r"^\s*\[", existing, maxsplit=1, flags=re.MULTILINE)[0]
     conflicts = []
-    for key in ("sandbox_mode", "default_permissions", "approval_policy", "approvals_reviewer"):
-        key_pattern = r'(?:' + re.escape(key) + r'|"' + re.escape(key) + r'"|\'' + re.escape(key) + r"\')"
-        if re.search(r"^\s*" + key_pattern + r"\s*=", root_region, re.MULTILINE):
+    managed_keys = {"sandbox_mode", "default_permissions", "approval_policy", "approvals_reviewer"}
+    for match in ROOT_ASSIGNMENT.finditer(root_region):
+        key = decode_toml_key(match.group(1))
+        if key in managed_keys:
             conflicts.append(key)
-    permissions = r'''(?:permissions|"permissions"|'permissions')'''
-    profile = r'''(?:spex-project|"spex-project"|'spex-project')'''
-    if re.search(
-        r"^\s*\[\s*" + permissions + r"\s*\.\s*" + profile + r"(?:\s*\.|\s*\])",
-        existing,
-        re.MULTILINE,
+    if any(
+        decode_toml_key(match.group(1)) == "permissions"
+        and decode_toml_key(match.group(2)) == "spex-project"
+        for match in PROFILE_TABLE.finditer(existing)
     ):
         conflicts.append("permissions.spex-project")
     if conflicts:

--- a/spex/scripts/configure-codex-project.py
+++ b/spex/scripts/configure-codex-project.py
@@ -85,7 +85,7 @@ def merge_permissions(existing, block):
         return replace_block(existing, CONFIG_BEGIN, CONFIG_END, block)
     root_region = existing.split("\n[", 1)[0]
     conflicts = []
-    for key in ("default_permissions", "approval_policy", "approvals_reviewer"):
+    for key in ("sandbox_mode", "default_permissions", "approval_policy", "approvals_reviewer"):
         if re.search(r"^\s*" + key + r"\s*=", root_region, re.MULTILINE):
             conflicts.append(key)
     if re.search(r"^\s*\[permissions\.spex-project(?:\.|\])", existing, re.MULTILINE):
@@ -101,14 +101,24 @@ def permission_block(root, security):
     """Render current Codex permission-profile configuration."""
     if security == "safe":
         return ""
+    if security == "yolo":
+        return "\n".join(
+            [
+                CONFIG_BEGIN,
+                '# Generated from .specify/spex.json; edit that declaration, not this block.',
+                'sandbox_mode = "danger-full-access"',
+                'approval_policy = "never"',
+                CONFIG_END,
+            ]
+        )
     common = json.dumps(str(git_common_dir(root)))
-    reviewer = 'approvals_reviewer = "auto_review"' if security == "autonomous" else 'approval_policy = "never"'
     return "\n".join(
         [
             CONFIG_BEGIN,
             '# Generated from .specify/spex.json; edit that declaration, not this block.',
             'default_permissions = "spex-project"',
-            reviewer,
+            'approval_policy = "on-request"',
+            'approvals_reviewer = "auto_review"',
             "",
             '[permissions.spex-project.filesystem]',
             '":minimal" = "read"',
@@ -165,7 +175,11 @@ def configure(args):
     return {
         "status": "configured",
         "security": args.security,
-        "permissions": "unchanged" if args.security == "safe" else "spex-project",
+        "permissions": {
+            "safe": "unchanged",
+            "autonomous": "spex-project",
+            "yolo": "danger-full-access",
+        }[args.security],
         "config_changed": updated_config != config,
         "guidance_changed": updated_guidance != guidance,
     }

--- a/spex/scripts/configure-codex-project.py
+++ b/spex/scripts/configure-codex-project.py
@@ -86,9 +86,16 @@ def merge_permissions(existing, block):
     root_region = existing.split("\n[", 1)[0]
     conflicts = []
     for key in ("sandbox_mode", "default_permissions", "approval_policy", "approvals_reviewer"):
-        if re.search(r"^\s*" + key + r"\s*=", root_region, re.MULTILINE):
+        key_pattern = r'(?:' + re.escape(key) + r'|"' + re.escape(key) + r'"|\'' + re.escape(key) + r"\')"
+        if re.search(r"^\s*" + key_pattern + r"\s*=", root_region, re.MULTILINE):
             conflicts.append(key)
-    if re.search(r"^\s*\[permissions\.spex-project(?:\.|\])", existing, re.MULTILINE):
+    permissions = r'''(?:permissions|"permissions"|'permissions')'''
+    profile = r'''(?:spex-project|"spex-project"|'spex-project')'''
+    if re.search(
+        r"^\s*\[\s*" + permissions + r"\s*\.\s*" + profile + r"(?:\s*\.|\s*\])",
+        existing,
+        re.MULTILINE,
+    ):
         conflicts.append("permissions.spex-project")
     if conflicts:
         raise ConfigurationError(

--- a/spex/setup.yml
+++ b/spex/setup.yml
@@ -504,8 +504,12 @@ steps:
           type: shell
           run: |
             SOURCE="${SPEX_SOURCE:-$SPECKIT_WORKFLOW_DIR}"
-            "$SOURCE/scripts/configure-codex-project.py" --root "$(pwd)" \
-              --security "{{ steps.selected-security.output.stdout }}" >/dev/null
+            if ! RESULT=$("$SOURCE/scripts/configure-codex-project.py" --root "$(pwd)" \
+              --security "{{ steps.selected-security.output.stdout }}"); then
+              printf '%s\n' "$RESULT" >&2
+              echo "ERROR: Codex project configuration was refused." >&2
+              exit 1
+            fi
             echo "Codex project guidance and permissions configured" >&2
       opencode:
         - id: opencode-plugin

--- a/spex/setup.yml
+++ b/spex/setup.yml
@@ -500,49 +500,13 @@ steps:
             fi
             echo "Status line configured" >&2
       codex:
-        - id: codex-hooks
+        - id: codex-project
           type: shell
           run: |
             SOURCE="${SPEX_SOURCE:-$SPECKIT_WORKFLOW_DIR}"
-            mkdir -p .codex
-            CODEX_PRETOOL="$(cd "$SOURCE/scripts/adapters/codex" 2>/dev/null && pwd)/pretool-gate.py"
-            CODEX_CONTEXT="$(cd "$SOURCE/scripts/adapters/codex" 2>/dev/null && pwd)/context-hook.py"
-            PYTHON_RESOLVE="$(cd "$SOURCE/scripts/hooks" 2>/dev/null && pwd)/python-resolve.sh"
-            if [ ! -f "$CODEX_PRETOOL" ] || [ ! -f "$CODEX_CONTEXT" ]; then
-              echo "WARNING: Codex adapter scripts not found" >&2
-              exit 0
-            fi
-            CTX_CMD="sh $PYTHON_RESOLVE $CODEX_CONTEXT"
-            PRE_CMD="sh $PYTHON_RESOLVE $CODEX_PRETOOL"
-            if [ -f .codex/hooks.json ]; then
-              TMP=$(mktemp)
-              jq --arg ctx "$CTX_CMD" --arg pre "$PRE_CMD" '
-                .hooks.UserPromptSubmit = [(.hooks.UserPromptSubmit // [] | .[] | select(
-                  .hooks[0].command | test("context-hook\\.py") | not
-                ))] + [{hooks: [{command: $ctx, type: "command"}]}] |
-                .hooks.PreToolUse = [(.hooks.PreToolUse // [] | .[] | select(
-                  .hooks[0].command | test("pretool-gate\\.py") | not
-                ))] + [{hooks: [{command: $pre, type: "command"}]}]
-              ' .codex/hooks.json > "$TMP"
-              mv "$TMP" .codex/hooks.json
-            else
-              jq -n --arg ctx "$CTX_CMD" --arg pre "$PRE_CMD" '{
-                hooks: {
-                  UserPromptSubmit: [{hooks: [{command: $ctx, type: "command"}]}],
-                  PreToolUse: [{hooks: [{command: $pre, type: "command"}]}]
-                }
-              }' > .codex/hooks.json
-            fi
-            echo "Codex adapter hooks installed" >&2
-        - id: codex-agents-md
-          type: shell
-          run: |
-            SOURCE="${SPEX_SOURCE:-$SPECKIT_WORKFLOW_DIR}"
-            TEMPLATE="$SOURCE/templates/agents-md/codex.md"
-            if [ -f "$TEMPLATE" ]; then
-              cp "$TEMPLATE" AGENTS.md
-              echo "AGENTS.md generated for Codex" >&2
-            fi
+            "$SOURCE/scripts/configure-codex-project.py" --root "$(pwd)" \
+              --security "{{ steps.selected-security.output.stdout }}" >/dev/null
+            echo "Codex project guidance and permissions configured" >&2
       opencode:
         - id: opencode-plugin
           type: shell
@@ -620,7 +584,7 @@ steps:
             - id: codex-permissions
               type: shell
               run: |
-                echo "Codex permissions are managed via .codex/hooks.json (configured in adapt-harness step)" >&2
+                echo "Codex permissions are managed in .codex/config.toml (configured in adapt-harness step)" >&2
           opencode:
             - id: opencode-permissions
               type: shell

--- a/spex/setup.yml
+++ b/spex/setup.yml
@@ -409,8 +409,8 @@ steps:
           prompt: >-
             Select requested project security. Safe (recommended) preserves the
             host policy. Autonomous reduces prompts for enumerated Spex project
-            operations. YOLO requests the broadest project-local autonomy the
-            active harness can safely express. Reply: safe, autonomous, or yolo.
+            operations. YOLO requests unrestricted filesystem and network access
+            without approval prompts. Reply: safe, autonomous, or yolo.
           integration: "{{ steps.detect-agent.output.stdout }}"
     default:
       - id: security-noop

--- a/spex/templates/agents-md/codex.md
+++ b/spex/templates/agents-md/codex.md
@@ -1,52 +1,14 @@
-# spex: Spec-Driven Development Plugin
+<!-- >>> spex managed Codex guidance >>>
+This block is managed from .specify/spex.json. Keep project guidance outside it.
+-->
 
-## Workflow
+## Spex workflow in Codex
 
-spex enforces a spec-first development workflow. All features follow:
-specify -> clarify -> plan -> tasks -> implement -> review -> verify
+Invoke Spex skills with `$`, for example `$speckit-specify`, `$speckit-plan`,
+`$speckit-tasks`, and `$speckit-implement`. Do not print `/...` examples for
+Codex skills. Use `$speckit-spex-help` for the current command list.
 
-## Enforcement
+When a Spex skill needs a choice, present a short numbered list inline and wait
+for the answer. Use Codex subagents only when the user requests parallel work.
 
-Hooks enforce this workflow mechanically via PreToolUse and UserPromptSubmit hooks.
-You do not need to remember the rules; the hooks will block invalid actions.
-
-## Interactive Prompts
-
-Codex does NOT have the AskUserQuestion tool. When presenting choices,
-use an inline numbered list and wait for the user's response.
-
-## Parallel Work
-
-Use **subagents** when explicitly requested for parallel task dispatch.
-Each subagent should work on independent tasks. Coordinate completion
-before proceeding to review.
-
-## Context Management
-
-Start a **new session** to reset context when token usage is high.
-There is no /clear command on Codex.
-
-## Worktrees
-
-Codex does NOT have the EnterWorktree tool. To create isolated workspaces,
-use git commands directly:
-
-```bash
-git worktree add ../<feature-name> -b <branch-name>
-```
-
-When done, clean up with:
-
-```bash
-git worktree remove ../<feature-name>
-```
-
-## Commands
-
-- `/spex:ship` - Full autonomous workflow (specify through verify)
-- `/spex:brainstorm` - Refine ideas into specifications
-- `/spex:help` - Quick reference for all commands
-- `/speckit-specify` - Create feature specification
-- `/speckit-plan` - Create implementation plan
-- `/speckit-tasks` - Generate task breakdown
-- `/speckit-implement` - Execute implementation
+<!-- <<< spex managed Codex guidance <<< -->

--- a/tests/test_codex_project.py
+++ b/tests/test_codex_project.py
@@ -97,6 +97,26 @@ class CodexProjectTests(unittest.TestCase):
             self.assertIn("refusing to override", result.stdout)
             self.assertEqual(path.read_text(), 'approval_policy = "on-request"\n')
 
+    def test_refuses_quoted_user_owned_permission_selectors(self):
+        """Quoted TOML keys and table segments retain user ownership."""
+        configurations = (
+            '"sandbox_mode" = "workspace-write"\n',
+            '[permissions."spex-project"]\n',
+        )
+        for configuration in configurations:
+            with self.subTest(configuration=configuration), tempfile.TemporaryDirectory() as raw:
+                root = Path(raw)
+                path = root / ".codex/config.toml"
+                path.parent.mkdir()
+                path.write_text(configuration)
+                result = subprocess.run(
+                    ["python3", str(TOOL), "--root", str(root), "--security", "yolo"],
+                    capture_output=True, text=True, check=False,
+                )
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("refusing to override", result.stdout)
+                self.assertEqual(path.read_text(), configuration)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_codex_project.py
+++ b/tests/test_codex_project.py
@@ -102,6 +102,8 @@ class CodexProjectTests(unittest.TestCase):
         configurations = (
             '"sandbox_mode" = "workspace-write"\n',
             '[permissions."spex-project"]\n',
+            '"approval\\u005fpolicy" = "on-request"\n',
+            '[permissions."spex\\u002dproject"]\n',
         )
         for configuration in configurations:
             with self.subTest(configuration=configuration), tempfile.TemporaryDirectory() as raw:

--- a/tests/test_codex_project.py
+++ b/tests/test_codex_project.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Contract tests for current Codex project setup."""
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "spex/scripts/configure-codex-project.py"
+
+
+class CodexProjectTests(unittest.TestCase):
+    """Verify prompt-free bounded configuration and ownership behavior."""
+
+    def run_tool(self, root, security="yolo"):
+        """Run the configurator and require a successful JSON response."""
+        result = subprocess.run(
+            ["python3", str(TOOL), "--root", str(root), "--security", security],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        return json.loads(result.stdout)
+
+    def test_yolo_covers_linked_worktree_git_without_network_or_prompts(self):
+        """YOLO writes workspace and shared Git metadata but fails closed beyond them."""
+        with tempfile.TemporaryDirectory() as raw:
+            repository = Path(raw) / "repository"
+            worktree = Path(raw) / "feature"
+            subprocess.run(["git", "init", "-q", str(repository)], check=True)
+            subprocess.run(["git", "-C", str(repository), "config", "user.name", "Test"], check=True)
+            subprocess.run(["git", "-C", str(repository), "config", "user.email", "test@example.invalid"], check=True)
+            subprocess.run(["git", "-C", str(repository), "commit", "--allow-empty", "-q", "-m", "initial"], check=True)
+            subprocess.run(["git", "-C", str(repository), "worktree", "add", "-q", "-b", "feature", str(worktree)], check=True)
+            payload = self.run_tool(worktree)
+            config = (worktree / ".codex/config.toml").read_text()
+            self.assertEqual(payload["security"], "yolo")
+            self.assertIn('approval_policy = "never"', config)
+            self.assertIn(json.dumps(str((repository / ".git").resolve())) + ' = "write"', config)
+            self.assertIn("enabled = false", config)
+
+    def test_refresh_preserves_user_guidance_and_is_idempotent(self):
+        """Refresh only owns sentinel blocks and produces stable bytes."""
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            (root / "AGENTS.md").write_text("# Team rules\n")
+            self.run_tool(root, "autonomous")
+            first_config = (root / ".codex/config.toml").read_bytes()
+            first_agents = (root / "AGENTS.md").read_bytes()
+            self.run_tool(root, "autonomous")
+            self.assertEqual(first_config, (root / ".codex/config.toml").read_bytes())
+            self.assertEqual(first_agents, (root / "AGENTS.md").read_bytes())
+            self.assertTrue((root / "AGENTS.md").read_text().startswith("# Team rules\n"))
+
+    def test_safe_removes_only_managed_permissions(self):
+        """Safe mode removes Spex permissions and retains user configuration."""
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            self.run_tool(root)
+            path = root / ".codex/config.toml"
+            path.write_text(path.read_text() + '\nmodel = "user-choice"\n')
+            self.run_tool(root, "safe")
+            self.assertEqual(path.read_text(), 'model = "user-choice"\n')
+
+    def test_refuses_user_owned_permission_selector(self):
+        """Setup never silently replaces a user's existing Codex policy."""
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            path = root / ".codex/config.toml"
+            path.parent.mkdir()
+            path.write_text('approval_policy = "on-request"\n')
+            result = subprocess.run(
+                ["python3", str(TOOL), "--root", str(root), "--security", "yolo"],
+                capture_output=True, text=True, check=False,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("refusing to override", result.stdout)
+            self.assertEqual(path.read_text(), 'approval_policy = "on-request"\n')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_project.py
+++ b/tests/test_codex_project.py
@@ -13,7 +13,7 @@ TOOL = ROOT / "spex/scripts/configure-codex-project.py"
 
 
 class CodexProjectTests(unittest.TestCase):
-    """Verify prompt-free bounded configuration and ownership behavior."""
+    """Verify security-mode configuration and ownership behavior."""
 
     def run_tool(self, root, security="yolo"):
         """Run the configurator and require a successful JSON response."""
@@ -24,8 +24,21 @@ class CodexProjectTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
         return json.loads(result.stdout)
 
-    def test_yolo_covers_linked_worktree_git_without_network_or_prompts(self):
-        """YOLO writes workspace and shared Git metadata but fails closed beyond them."""
+    def test_yolo_is_unrestricted_without_prompts(self):
+        """YOLO uses Codex's unrestricted sandbox and never asks for approval."""
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            payload = self.run_tool(root)
+            config = (root / ".codex/config.toml").read_text()
+            self.assertEqual(payload["security"], "yolo")
+            self.assertEqual(payload["permissions"], "danger-full-access")
+            self.assertIn('sandbox_mode = "danger-full-access"', config)
+            self.assertIn('approval_policy = "never"', config)
+            self.assertNotIn("[permissions.spex-project", config)
+            self.assertNotIn("enabled = false", config)
+
+    def test_autonomous_covers_linked_worktree_git_with_bounded_permissions(self):
+        """Autonomous bounds writes while auto-reviewing requests beyond them."""
         with tempfile.TemporaryDirectory() as raw:
             repository = Path(raw) / "repository"
             worktree = Path(raw) / "feature"
@@ -34,10 +47,12 @@ class CodexProjectTests(unittest.TestCase):
             subprocess.run(["git", "-C", str(repository), "config", "user.email", "test@example.invalid"], check=True)
             subprocess.run(["git", "-C", str(repository), "commit", "--allow-empty", "-q", "-m", "initial"], check=True)
             subprocess.run(["git", "-C", str(repository), "worktree", "add", "-q", "-b", "feature", str(worktree)], check=True)
-            payload = self.run_tool(worktree)
+            payload = self.run_tool(worktree, "autonomous")
             config = (worktree / ".codex/config.toml").read_text()
-            self.assertEqual(payload["security"], "yolo")
-            self.assertIn('approval_policy = "never"', config)
+            self.assertEqual(payload["security"], "autonomous")
+            self.assertEqual(payload["permissions"], "spex-project")
+            self.assertIn('approval_policy = "on-request"', config)
+            self.assertIn('approvals_reviewer = "auto_review"', config)
             self.assertIn(json.dumps(str((repository / ".git").resolve())) + ' = "write"', config)
             self.assertIn("enabled = false", config)
 

--- a/tests/test_workflow_setup.sh
+++ b/tests/test_workflow_setup.sh
@@ -4,9 +4,11 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 TEST_REPO="$(mktemp -d "${TMPDIR:-/tmp}/spex-workflow-setup.XXXXXX")"
 LEGACY_REPO="$(mktemp -d "${TMPDIR:-/tmp}/spex-workflow-legacy.XXXXXX")"
-trap 'rm -rf -- "$TEST_REPO" "$LEGACY_REPO"' EXIT
+CODEX_REPO="$(mktemp -d "${TMPDIR:-/tmp}/spex-workflow-codex.XXXXXX")"
+trap 'rm -rf -- "$TEST_REPO" "$LEGACY_REPO" "$CODEX_REPO"' EXIT
 git -C "$TEST_REPO" init -q
 git -C "$LEGACY_REPO" init -q
+git -C "$CODEX_REPO" init -q
 
 run_setup() {
   (
@@ -42,9 +44,19 @@ legacy="$({
 jq -e '.status == "completed"' <<<"$legacy" >/dev/null
 jq -e '.security == "autonomous"' "$LEGACY_REPO/.specify/spex.json" >/dev/null
 
+mkdir -p "$CODEX_REPO/.codex"
+printf '%s\n' 'approval_policy = "on-request"' > "$CODEX_REPO/.codex/config.toml"
+codex_refusal="$({
+  cd "$CODEX_REPO"
+  SPEX_SOURCE="$REPO_ROOT/spex" specify workflow run "$REPO_ROOT/spex/setup.yml" --json \
+    -i integration=codex -i extensions=recommended -i security=yolo
+} || true)"
+jq -e '.status == "failed" and .current_step_id == "codex-project"' \
+  <<<"$codex_refusal" >/dev/null
+
 if find "$TEST_REPO" -maxdepth 2 -type d -name '*materializ*' | grep -q .; then
   echo "FAIL: workflow setup created a staged distribution" >&2
   exit 1
 fi
 
-echo "PASS: workflow setup persists intent, migrates legacy permissions, and refreshes without materialization"
+echo "PASS: workflow setup persists intent, migrates legacy permissions, propagates Codex refusal, and refreshes without materialization"

--- a/tests/test_workflow_setup.sh
+++ b/tests/test_workflow_setup.sh
@@ -54,7 +54,7 @@ codex_refusal="$({
 jq -e '.status == "failed" and .current_step_id == "codex-project"' \
   <<<"$codex_refusal" >/dev/null
 
-if find "$TEST_REPO" -maxdepth 2 -type d -name '*materializ*' | grep -q .; then
+if find "$TEST_REPO" "$CODEX_REPO" -maxdepth 2 -type d -name '*materializ*' | grep -q .; then
   echo "FAIL: workflow setup created a staged distribution" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- merge Codex-native `$skill` guidance into user-owned `AGENTS.md`
- map Safe, Autonomous, and bounded YOLO to current Codex permission profiles
- include linked-worktree shared Git metadata so normal Git operations do not prompt
- keep command network disabled and preserve user-owned Codex settings
- support Python 3.9 without `tomllib` or third-party dependencies

## Deliberate scope

This stacked PR does not package a plugin or install hooks. Current Codex plugins can bundle hooks natively, so those belong to the thin discoverability PR. It also excludes materialization, state/recovery, and Teams.

## Validation

- `make test-codex-project` (4 tests)
- `make test-setup-profile`
- `make test-workflow-setup`
- `make test-generated-trees`
- `make validate`
- `make sync-scripts-check`
- Python 3.9 compile check
- `git diff --check`

## Review focus

Use `specs/049-codex-native-integration/REVIEWERS.md`. Review against the stacked base branch `048-workflow-first-setup`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Codex project setup that configures managed guidance/permissions and updates `AGENTS.md` with `$skill`-based workflow commands.
  * Supports Safe, Autonomous, and YOLO modes, including prompt-free YOLO and linked-worktree Git handling.
* **Bug Fixes**
  * Prevents overwriting user-owned Codex permission settings and refuses conflicting or user-managed selectors.
* **Documentation**
  * Expanded Codex setup, mapping, review, and integration specs, plus updated the Codex agent template.
* **Tests**
  * Added Codex project contract tests and a new `make test-codex-project` target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->